### PR TITLE
chore(dep): remove dependencies to javafx 

### DIFF
--- a/extensions/streaming/api/src/main/java/com/fluxtion/ext/streaming/api/util/Pair.java
+++ b/extensions/streaming/api/src/main/java/com/fluxtion/ext/streaming/api/util/Pair.java
@@ -1,0 +1,20 @@
+package com.fluxtion.ext.streaming.api.util;
+
+public class Pair<X, Y> {
+
+  private final X key;
+  private final Y value;
+
+  public Pair(X key, Y value) {
+    this.key = key;
+    this.value = value;
+  }
+
+  public X getKey() {
+    return key;
+  }
+
+  public Y getValue() {
+    return value;
+  }
+}

--- a/extensions/streaming/builder/src/test/java/com/fluxtion/ext/declarative/builder/stream/MapFunctions.java
+++ b/extensions/streaming/builder/src/test/java/com/fluxtion/ext/declarative/builder/stream/MapFunctions.java
@@ -17,8 +17,8 @@
  */
 package com.fluxtion.ext.declarative.builder.stream;
 
-import javafx.util.Pair;
 
+import com.fluxtion.ext.streaming.api.util.Pair;
 
 /**
  *

--- a/extensions/streaming/builder/src/test/java/com/fluxtion/ext/declarative/builder/stream/MapStaticFunctions.java
+++ b/extensions/streaming/builder/src/test/java/com/fluxtion/ext/declarative/builder/stream/MapStaticFunctions.java
@@ -1,6 +1,6 @@
 package com.fluxtion.ext.declarative.builder.stream;
 
-import javafx.util.Pair;
+import com.fluxtion.ext.streaming.api.util.Pair;
 
 /**
  *

--- a/extensions/streaming/builder/src/test/java/com/fluxtion/ext/declarative/builder/stream/StreamingMapTest.java
+++ b/extensions/streaming/builder/src/test/java/com/fluxtion/ext/declarative/builder/stream/StreamingMapTest.java
@@ -20,9 +20,10 @@ package com.fluxtion.ext.declarative.builder.stream;
 import com.fluxtion.ext.streaming.api.Wrapper;
 import com.fluxtion.ext.streaming.api.numeric.MutableNumber;
 import static com.fluxtion.ext.streaming.builder.event.EventSelect.select;
-import javafx.util.Pair;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+
+import com.fluxtion.ext.streaming.api.util.Pair;
 import org.junit.Test;
 
 /**

--- a/extensions/text/builder/src/main/java/com/fluxtion/ext/text/builder/csv/RulesEvaluatorBuilder.java
+++ b/extensions/text/builder/src/main/java/com/fluxtion/ext/text/builder/csv/RulesEvaluatorBuilder.java
@@ -36,10 +36,10 @@ import com.fluxtion.ext.text.api.csv.RowProcessor;
 import com.fluxtion.ext.text.api.csv.RulesEvaluator;
 import com.fluxtion.ext.text.api.csv.ValidationLogSink.LogNotifier;
 import com.fluxtion.ext.text.api.util.EventPublsher;
+import com.fluxtion.ext.streaming.api.util.Pair;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-import javafx.util.Pair;
 
 /**
  * A RulesEvaluator aggregates a set of rules and reports success if all rules


### PR DESCRIPTION
Hello,

This is quick fix in order to build on JDK >=9. Javafx has been removed by the jigsasw project. 
The AdoptOpenJDK 8 is [broken too](https://github.com/AdoptOpenJDK/openjdk-build/issues/577).

I'm not fond of creating a pair boilerplate class but it seems to be a necessary evil here. If you have any better idea, I'll be glad to change it