### PR TITLE
chore(pom): remove unneeded dependencies

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -54,14 +54,6 @@ along with this program.  If not, see
             <groupId>it.unimi.dsi</groupId>
             <artifactId>fastutil</artifactId>
         </dependency>
-        <dependency>
-            <groupId>net.vidageek</groupId>
-            <artifactId>mirror</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
     </dependencies>
     <properties>
         <netbeans.hint.license>ssl1</netbeans.hint.license>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -80,12 +80,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses />.
             <version>3.1.1</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.fluxtion</groupId>
             <artifactId>generator</artifactId>
             <scope>compile</scope>
@@ -98,7 +92,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses />.
         <dependency>
             <groupId>io.github.classgraph</groupId>
             <artifactId>classgraph</artifactId>  
-            <version>4.6.27</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
`junit` was not test scoped and `mirror` doesn't seems used by the API at first glance