### PR TITLE
chore(typo): fix some typos

### DIFF
--- a/api/src/main/java/com/fluxtion/api/event/EventPublisher.java
+++ b/api/src/main/java/com/fluxtion/api/event/EventPublisher.java
@@ -21,6 +21,7 @@ import com.fluxtion.api.annotations.OnParentUpdate;
 import com.fluxtion.api.lifecycle.EventHandler;
 import java.util.ArrayList;
 import java.util.Arrays;
+import lombok.EqualsAndHashCode;
 
 /**
  * A node in a SEP that publishes an {@link Event} to a registered
@@ -29,12 +30,13 @@ import java.util.Arrays;
  *
  * @author V12 Technology Ltd.
  */
-public class EventPublsher<T extends Event> {
+@EqualsAndHashCode
+public class EventPublisher<T extends Event> {
 
     public Event[] nodeSource = new Event[0];
-    private EventHandler[] handlers;
+    private EventHandler<T>[] handlers;
 
-    public EventPublsher() {
+    public EventPublisher() {
         init();
     }
     
@@ -45,7 +47,7 @@ public class EventPublsher<T extends Event> {
         }
     }
 
-    public EventPublsher<T> addEventSource(T node) {
+    public EventPublisher<T> addEventSource(T node) {
         ArrayList<Event> nodes = new ArrayList<>(Arrays.asList(nodeSource));
         nodes.add(node);
         nodeSource = nodes.toArray(nodeSource);
@@ -71,35 +73,6 @@ public class EventPublsher<T extends Event> {
 //        if (nodeSource == null) {
 //            nodeSource = new Event[0];
 //        }
-    }
-
-    @Override
-    public int hashCode() {
-        int hash = 7;
-        hash = 59 * hash + Arrays.deepHashCode(this.nodeSource);
-        hash = 59 * hash + Arrays.deepHashCode(this.handlers);
-        return hash;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        final EventPublsher<?> other = (EventPublsher<?>) obj;
-        if (!Arrays.deepEquals(this.nodeSource, other.nodeSource)) {
-            return false;
-        }
-        if (!Arrays.deepEquals(this.handlers, other.handlers)) {
-            return false;
-        }
-        return true;
     }
 
 }

--- a/builder/src/main/java/com/fluxtion/builder/annotation/SepBuilder.java
+++ b/builder/src/main/java/com/fluxtion/builder/annotation/SepBuilder.java
@@ -85,7 +85,7 @@ public @interface SepBuilder {
 
     /**
      * <b>USE WITH CARE<b><p>
-     * Cleans output directory of all files before generating artefacts. if two
+     * Cleans output directory of all files before generating artifacts. if two
      * annotations are configured in the same build with the
      * same output directory, setting this option to true will have
      * unpredictable results.

--- a/builder/src/main/java/com/fluxtion/builder/annotation/SepInstance.java
+++ b/builder/src/main/java/com/fluxtion/builder/annotation/SepInstance.java
@@ -85,7 +85,7 @@ public @interface SepInstance {
 
     /**
      * <b>USE WITH CARE<b><p>
-     * Cleans output directory of all files before generating artefacts. if two
+     * Cleans output directory of all files before generating artifacts. if two
      * annotations are configured in the same build with the same output
      * directory, setting this option to true will have unpredictable results.
      *

--- a/builder/src/main/java/com/fluxtion/builder/debug/SepDebugger.java
+++ b/builder/src/main/java/com/fluxtion/builder/debug/SepDebugger.java
@@ -143,7 +143,7 @@ public class SepDebugger {
 
     public void eventInvocation(Event event) {
         this.currentEvent = event;
-        //TODO add stats for recording the event cound, both filtered and aggregated by ID
+        //TODO add stats for recording the event count, both filtered and aggregated by ID
     }
 
     public Event getCurrentEvent() {

--- a/builder/src/main/java/com/fluxtion/builder/event/EventPublisherBuilder.java
+++ b/builder/src/main/java/com/fluxtion/builder/event/EventPublisherBuilder.java
@@ -17,28 +17,28 @@
 package com.fluxtion.builder.event;
 
 import com.fluxtion.api.event.Event;
-import com.fluxtion.api.event.EventPublsher;
+import com.fluxtion.api.event.EventPublisher;
 import com.fluxtion.builder.generation.GenerationContext;
 
 /**
- * Builder used to add a {@link EventPublsher} via static helper functions. The
+ * Builder used to add a {@link EventPublisher} via static helper functions. The
  * generated
- * EventPublsher will be automatically added to the graph context as will any
+ * EventPublisher will be automatically added to the graph context as will any
  * supplied {@link Event} source.
  *
  * @author V12 Technology Ltd.
  */
 public class EventPublisherBuilder {
 
-    public static <T extends Event> EventPublsher eventSource(T source) {
-        EventPublsher publisher = GenerationContext.SINGLETON.addOrUseExistingNode(new EventPublsher());
+    public static <T extends Event> EventPublisher eventSource(T source) {
+        EventPublisher<T> publisher = GenerationContext.SINGLETON.addOrUseExistingNode(new EventPublisher<>());
         publisher.addEventSource(source);
         GenerationContext.SINGLETON.addOrUseExistingNode(source);
         return publisher;
     }
 
-    public static <T extends Event> EventPublsher eventSource(T source, String name) {
-        EventPublsher publisher = GenerationContext.SINGLETON.addOrUseExistingNode(new EventPublsher());
+    public static <T extends Event> EventPublisher eventSource(T source, String name) {
+        EventPublisher<T> publisher = GenerationContext.SINGLETON.addOrUseExistingNode(new EventPublisher<>());
         GenerationContext.SINGLETON.nameNode(publisher, name);
         publisher.addEventSource(source);
         GenerationContext.SINGLETON.addOrUseExistingNode(source);

--- a/builder/src/main/java/com/fluxtion/builder/event/test/AssertTestEvent.java
+++ b/builder/src/main/java/com/fluxtion/builder/event/test/AssertTestEvent.java
@@ -25,7 +25,7 @@ public class AssertTestEvent extends com.fluxtion.api.event.Event {
 
     public static final int ID = 1099;
     public final String nodeName;
-    //filter ids for lifecyle events
+    //filter ids for lifecycle events
     public static final int FILTER_ID_INIT = 1;
     public static final int FILTER_ID_BATCH_PAUSE = 2;
     public static final int FILTER_ID_BATCH_END = 3;

--- a/builder/src/main/java/com/fluxtion/builder/generation/GenerationContext.java
+++ b/builder/src/main/java/com/fluxtion/builder/generation/GenerationContext.java
@@ -196,12 +196,12 @@ public class GenerationContext {
         cacheMap = new HashMap<>();
     }
 
-    private GenerationContext(ClassLoader classLoasder, String packageName, String sepClassName, File outputDirectory, File resourcesRootDirectory, File buildOutputDirectory, CachedCompiler cachedCompiler) {
+    private GenerationContext(ClassLoader classLoader, String packageName, String sepClassName, File outputDirectory, File resourcesRootDirectory, File buildOutputDirectory, CachedCompiler cachedCompiler) {
         this.packageName = packageName;
         this.sepClassName = sepClassName;
         this.sourceRootDirectory = outputDirectory;
         this.resourcesRootDirectory = resourcesRootDirectory;
-        this.classLoader = classLoasder;
+        this.classLoader = classLoader;
         if (cachedCompiler == null) {
             javaCompiler = new CachedCompiler(null, buildOutputDirectory);
         } else {

--- a/builder/src/main/java/com/fluxtion/builder/node/DeclarativeNodeConfiguration.java
+++ b/builder/src/main/java/com/fluxtion/builder/node/DeclarativeNodeConfiguration.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import lombok.EqualsAndHashCode;
 
 /**
  * Provides data driven SEP generation. 
@@ -28,7 +29,8 @@ import java.util.Set;
  * <h2>Doc to be completed</h2>
  * @author Greg Higgins
  */
-public final class DeclarativeNodeConiguration {
+@EqualsAndHashCode
+public final class DeclarativeNodeConfiguration {
 
     /**
      * The root nodes to create and the variable names they should be mapped to.
@@ -63,7 +65,7 @@ public final class DeclarativeNodeConiguration {
      */
     public final Map config;
 
-    public DeclarativeNodeConiguration(Map<Class, String> rootNodeMappings, Set<Class<? extends NodeFactory>> factoryList, Map config) {
+    public DeclarativeNodeConfiguration(Map<Class, String> rootNodeMappings, Set<Class<? extends NodeFactory>> factoryList, Map config) {
         this(rootNodeMappings, factoryList, config, null);
     }
 
@@ -75,47 +77,11 @@ public final class DeclarativeNodeConiguration {
      * @param factorySet 
      */
     @SuppressWarnings("unchecked")
-    public DeclarativeNodeConiguration(Map<Class, String> rootNodeMappings, Set<Class<? extends NodeFactory>> factoryList, Map config, Set<NodeFactory<?>> factorySet) {
+    public DeclarativeNodeConfiguration(Map<Class, String> rootNodeMappings, Set<Class<? extends NodeFactory>> factoryList, Map config, Set<NodeFactory<?>> factorySet) {
         this.rootNodeMappings = rootNodeMappings == null ? Collections.EMPTY_MAP : rootNodeMappings;
         this.factoryClassSet = factoryList == null ? new HashSet<>() : factoryList;
         this.factorySet = factorySet == null ? new HashSet<>() : factorySet;
         this.config = config == null ? Collections.EMPTY_MAP : config;
         //this.proxyClassMap = new HashMap<>();
     }
-
-    @Override
-    public int hashCode() {
-        int hash = 7;
-        hash = 89 * hash + Objects.hashCode(this.rootNodeMappings);
-        hash = 89 * hash + Objects.hashCode(this.factoryClassSet);
-        hash = 89 * hash + Objects.hashCode(this.factorySet);
-        hash = 89 * hash + Objects.hashCode(this.config);
-        return hash;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        final DeclarativeNodeConiguration other = (DeclarativeNodeConiguration) obj;
-        if (!Objects.equals(this.rootNodeMappings, other.rootNodeMappings)) {
-            return false;
-        }
-        if (!Objects.equals(this.factoryClassSet, other.factoryClassSet)) {
-            return false;
-        }
-        if (!Objects.equals(this.factorySet, other.factorySet)) {
-            return false;
-        }
-        if (!Objects.equals(this.config, other.config)) {
-            return false;
-        }
-        return true;
-    }
-
-    
 }

--- a/builder/src/main/java/com/fluxtion/builder/node/SEPConfig.java
+++ b/builder/src/main/java/com/fluxtion/builder/node/SEPConfig.java
@@ -163,7 +163,7 @@ public class SEPConfig {
     /**
      * Node Factory configuration
      */
-    public DeclarativeNodeConiguration declarativeConfig;
+    public DeclarativeNodeConfiguration declarativeConfig;
 
     //MAPPING
     /**

--- a/extensions/text/builder/src/test/java/com/fluxtion/ext/futext/builder/filter/TextMatchTest.java
+++ b/extensions/text/builder/src/test/java/com/fluxtion/ext/futext/builder/filter/TextMatchTest.java
@@ -16,7 +16,7 @@
  */
 package com.fluxtion.ext.futext.builder.filter;
 
-import com.fluxtion.builder.node.DeclarativeNodeConiguration;
+import com.fluxtion.builder.node.DeclarativeNodeConfiguration;
 import com.fluxtion.builder.node.NodeFactory;
 import com.fluxtion.builder.node.SEPConfig;
 import com.fluxtion.ext.text.builder.ascii.AsciiMatchFilterFactory;
@@ -61,7 +61,7 @@ public class TextMatchTest extends BaseSepTest {
             addPublicNode(new TextMatchPrinter("ccypair=\"eurusd\""), MATCHER_VARIABLE_NAME);
             Set<Class<? extends NodeFactory>> factoryList = new HashSet<>();
             factoryList.add(AsciiMatchFilterFactory.class);
-            declarativeConfig = new DeclarativeNodeConiguration(null, factoryList, null);
+            declarativeConfig = new DeclarativeNodeConfiguration(null, factoryList, null);
         }
     }
 

--- a/generator/src/main/java/com/fluxtion/generator/compiler/SepCompiler.java
+++ b/generator/src/main/java/com/fluxtion/generator/compiler/SepCompiler.java
@@ -22,7 +22,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.core.util.StatusPrinter;
 import com.fluxtion.builder.generation.GenerationContext;
-import com.fluxtion.builder.node.DeclarativeNodeConiguration;
+import com.fluxtion.builder.node.DeclarativeNodeConfiguration;
 import com.fluxtion.builder.node.NodeFactory;
 import com.fluxtion.builder.node.SEPConfig;
 import com.fluxtion.generator.Generator;
@@ -159,8 +159,8 @@ public class SepCompiler {
             Yaml beanLoader = new Yaml();
             LOG.debug("loading SepFactoryConfigBean with beanLoader");
             SepFactoryConfigBean loadedConfig = beanLoader.loadAs(input, SepFactoryConfigBean.class);
-            LOG.debug("DeclarativeNodeConiguration load");
-            DeclarativeNodeConiguration cfgActual = loadedConfig.asDeclarativeNodeConiguration();
+            LOG.debug("DeclarativeNodeConfiguration load");
+            DeclarativeNodeConfiguration cfgActual = loadedConfig.asDeclarativeNodeConiguration();
             LOG.debug("searching for NodeFactory's");
             Set<Class<? extends NodeFactory>> class2Factory = NodeFactoryLocator.nodeFactorySet();
             cfgActual.factoryClassSet.addAll(class2Factory);
@@ -180,7 +180,7 @@ public class SepCompiler {
                 SepFactoryConfigBean loadedConfig = new SepFactoryConfigBean();
                 loadedConfig.setRootNodeMappings(rootNodeMappings);
                 loadedConfig.setConfig(new HashMap());
-                DeclarativeNodeConiguration cfgActual = loadedConfig.asDeclarativeNodeConiguration();
+                DeclarativeNodeConfiguration cfgActual = loadedConfig.asDeclarativeNodeConiguration();
                 Set<Class<? extends NodeFactory>> class2Factory = NodeFactoryLocator.nodeFactorySet();
                 cfgActual.factoryClassSet.addAll(class2Factory);
                 builderConfig.declarativeConfig = cfgActual;
@@ -195,7 +195,7 @@ public class SepCompiler {
         SepFactoryConfigBean loadedConfig = new SepFactoryConfigBean();
         Set<Class<? extends NodeFactory>> class2Factory = NodeFactoryLocator.nodeFactorySet();
         loadedConfig.setConfig(new HashMap());
-        DeclarativeNodeConiguration cfgActual = loadedConfig.asDeclarativeNodeConiguration();
+        DeclarativeNodeConfiguration cfgActual = loadedConfig.asDeclarativeNodeConiguration();
         if (builderConfig == null || builderConfig.declarativeConfig==null) {
             cfgActual.factoryClassSet.addAll(class2Factory);
             builderConfig.declarativeConfig = cfgActual;

--- a/generator/src/main/java/com/fluxtion/generator/compiler/SepFactoryConfigBean.java
+++ b/generator/src/main/java/com/fluxtion/generator/compiler/SepFactoryConfigBean.java
@@ -18,7 +18,7 @@
 package com.fluxtion.generator.compiler;
 
 import com.fluxtion.builder.generation.GenerationContext;
-import com.fluxtion.builder.node.DeclarativeNodeConiguration;
+import com.fluxtion.builder.node.DeclarativeNodeConfiguration;
 import com.fluxtion.builder.node.NodeFactory;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -75,7 +75,7 @@ public class SepFactoryConfigBean {
         this.config = config;
     }
 
-    public DeclarativeNodeConiguration asDeclarativeNodeConiguration() throws ClassNotFoundException {
+    public DeclarativeNodeConfiguration asDeclarativeNodeConiguration() throws ClassNotFoundException {
 
         // convert rootNodeMappings to classes
         HashMap<Class, String> rootClasses = null;
@@ -110,8 +110,8 @@ public class SepFactoryConfigBean {
             }
         }
 
-        DeclarativeNodeConiguration declarativeCfg
-                = new DeclarativeNodeConiguration(rootClasses, nodeFactoryClasses, config);
+        DeclarativeNodeConfiguration declarativeCfg
+                = new DeclarativeNodeConfiguration(rootClasses, nodeFactoryClasses, config);
         return declarativeCfg;
     }
 

--- a/generator/src/main/java/com/fluxtion/generator/model/TopologicallySortedDependecyGraph.java
+++ b/generator/src/main/java/com/fluxtion/generator/model/TopologicallySortedDependecyGraph.java
@@ -25,7 +25,7 @@ import com.fluxtion.api.annotations.PushReference;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.googlecode.gentyref.GenericTypeReflector;
-import com.fluxtion.builder.node.DeclarativeNodeConiguration;
+import com.fluxtion.builder.node.DeclarativeNodeConfiguration;
 import com.fluxtion.builder.node.NodeFactory;
 import com.fluxtion.builder.node.NodeRegistry;
 import com.fluxtion.builder.node.SEPConfig;
@@ -89,7 +89,7 @@ public class TopologicallySortedDependecyGraph implements NodeRegistry {
     private boolean processed = false;
     private int count;
 //    private static final int MAX_NAME_TRIES = 10000;
-    private final DeclarativeNodeConiguration declarativeNodeConiguration;
+    private final DeclarativeNodeConfiguration declarativeNodeConfiguration;
     private final HashMap<Class, CbMethodHandle> class2FactoryMethod;
     private final List publicNodeList;
     private final GenerationContext generationContext;
@@ -108,8 +108,8 @@ public class TopologicallySortedDependecyGraph implements NodeRegistry {
         this(null, publicNodes, null, null, null, null);
     }
 
-    public TopologicallySortedDependecyGraph(DeclarativeNodeConiguration declarativeNodeConiguration) {
-        this(null, null, declarativeNodeConiguration, null, null, null);
+    public TopologicallySortedDependecyGraph(DeclarativeNodeConfiguration declarativeNodeConfiguration) {
+        this(null, null, declarativeNodeConfiguration, null, null, null);
     }
 
     public TopologicallySortedDependecyGraph(List nodes, Map<Object, String> publicNodes) {
@@ -132,7 +132,7 @@ public class TopologicallySortedDependecyGraph implements NodeRegistry {
      * @param publicNodes Map of public available instances, the value is the
      * unique name of each instance. The names will override existing instances
      * in the nodes List or add the node to the set.
-     * @param declarativeNodeConiguration factory description
+     * @param declarativeNodeConfiguration factory description
      * @param strat NodeNameProducer strategy
      * @param context Generation context for this cycle
      * @param auditorMap Auditors to inject
@@ -140,7 +140,7 @@ public class TopologicallySortedDependecyGraph implements NodeRegistry {
      *
      */
     public TopologicallySortedDependecyGraph(List nodes, Map<Object, String> publicNodes,
-            DeclarativeNodeConiguration declarativeNodeConiguration,
+            DeclarativeNodeConfiguration declarativeNodeConfiguration,
             GenerationContext context, Map<String, Auditor> auditorMap, SEPConfig config) {
         this.config = config;
         this.nameStrategy = new NamingStrategy();
@@ -184,7 +184,7 @@ public class TopologicallySortedDependecyGraph implements NodeRegistry {
         });
         //declaritive nodes - add arguments to method and make defensive copy 
 //        declarativeNodeMap = new HashMap<>();
-        this.declarativeNodeConiguration = declarativeNodeConiguration;
+        this.declarativeNodeConfiguration = declarativeNodeConfiguration;
         this.generationContext = context;
     }
 
@@ -490,7 +490,7 @@ public class TopologicallySortedDependecyGraph implements NodeRegistry {
             return;
         }
 
-        if (declarativeNodeConiguration != null) {
+        if (declarativeNodeConfiguration != null) {
 
             /**
              * TODO create the NodeBuilder, passing this in as a reference loop
@@ -500,17 +500,17 @@ public class TopologicallySortedDependecyGraph implements NodeRegistry {
              *
              */
             //store the factory callbacks
-            for (Class<? extends NodeFactory> clazz : declarativeNodeConiguration.factoryClassSet) {
+            for (Class<? extends NodeFactory> clazz : declarativeNodeConfiguration.factoryClassSet) {
                 NodeFactory factory = clazz.newInstance();
                 registerNodeFactory(factory);
             }
             //override any any classes with pre-initialised NodeFactories
-            for (NodeFactory factory : declarativeNodeConiguration.factorySet) {
+            for (NodeFactory factory : declarativeNodeConfiguration.factorySet) {
                 registerNodeFactory(factory);
             }
             //loop through root instance and 
-            for (Map.Entry<Class, String> rootNode : declarativeNodeConiguration.rootNodeMappings.entrySet()) {
-                Object newNode = findOrCreateNode(rootNode.getKey(), declarativeNodeConiguration.config, rootNode.getValue());
+            for (Map.Entry<Class, String> rootNode : declarativeNodeConfiguration.rootNodeMappings.entrySet()) {
+                Object newNode = findOrCreateNode(rootNode.getKey(), declarativeNodeConfiguration.config, rootNode.getValue());
                 publicNodeList.add(newNode);
             }
         }

--- a/generator/src/test/java/com/fluxtion/generator/declarative/SimpleDeclarativeTest.java
+++ b/generator/src/test/java/com/fluxtion/generator/declarative/SimpleDeclarativeTest.java
@@ -22,7 +22,7 @@ import static junit.framework.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.fluxtion.builder.generation.GenerationContext;
-import com.fluxtion.builder.node.DeclarativeNodeConiguration;
+import com.fluxtion.builder.node.DeclarativeNodeConfiguration;
 import com.fluxtion.builder.node.NodeFactory;
 import com.fluxtion.builder.node.SEPConfig;
 import com.fluxtion.generator.Generator;
@@ -70,7 +70,7 @@ public class SimpleDeclarativeTest {
         Map<Class, String> rootNodeMappings = new HashMap<>();
         rootNodeMappings.put(KeyProcessorHistogram.class, "histogram");
 
-        DeclarativeNodeConiguration config = new DeclarativeNodeConiguration(rootNodeMappings, class2Factory, new HashMap<>());
+        DeclarativeNodeConfiguration config = new DeclarativeNodeConfiguration(rootNodeMappings, class2Factory, new HashMap<>());
 
         TopologicallySortedDependecyGraph instance = new TopologicallySortedDependecyGraph(config);
         instance.generateDependencyTree();
@@ -84,7 +84,7 @@ public class SimpleDeclarativeTest {
         rootNodeMappings.put(Calculator.class, "calculator");
         GenerationContext.setupStaticContext("com.fluxtion.test.template.java", "SimpleCalculator", new File("target/generated-test-sources/java/"), new File("target/generated-test-sources/resources/"));
 
-        DeclarativeNodeConiguration config = new DeclarativeNodeConiguration(rootNodeMappings, class2Factory, new HashMap<>());
+        DeclarativeNodeConfiguration config = new DeclarativeNodeConfiguration(rootNodeMappings, class2Factory, new HashMap<>());
         SEPConfig cfg = new SEPConfig();
         cfg.templateFile = "javaTemplate.vsl";
         cfg.declarativeConfig = config;
@@ -107,7 +107,7 @@ public class SimpleDeclarativeTest {
         Map<Class, String> rootNodeMappings = new HashMap<>();
         rootNodeMappings.put(WindowNode.class, "windowNode");
 
-        DeclarativeNodeConiguration config = new DeclarativeNodeConiguration(rootNodeMappings, class2Factory, null, factorySet);
+        DeclarativeNodeConfiguration config = new DeclarativeNodeConfiguration(rootNodeMappings, class2Factory, null, factorySet);
 
         TopologicallySortedDependecyGraph instance = new TopologicallySortedDependecyGraph(config);
         instance.generateDependencyTree();
@@ -127,7 +127,7 @@ public class SimpleDeclarativeTest {
         Map<Class, String> rootNodeMappings = new HashMap<>();
         rootNodeMappings.put(Calculator.class, "calcInjecting");
 
-        DeclarativeNodeConiguration config = new DeclarativeNodeConiguration(rootNodeMappings, class2Factory, null, factorySet);
+        DeclarativeNodeConfiguration config = new DeclarativeNodeConfiguration(rootNodeMappings, class2Factory, null, factorySet);
 
         TopologicallySortedDependecyGraph instance = new TopologicallySortedDependecyGraph(config);
         instance.generateDependencyTree();
@@ -150,7 +150,7 @@ public class SimpleDeclarativeTest {
         Map<Class, String> rootNodeMappings = new HashMap<>();
         rootNodeMappings.put(WindowNode.class, "windowNode");
 
-        DeclarativeNodeConiguration config = new DeclarativeNodeConiguration(rootNodeMappings, class2Factory, null, factorySet);
+        DeclarativeNodeConfiguration config = new DeclarativeNodeConfiguration(rootNodeMappings, class2Factory, null, factorySet);
 
         TopologicallySortedDependecyGraph instance = new TopologicallySortedDependecyGraph(config);
         instance.generateDependencyTree();
@@ -176,7 +176,7 @@ public class SimpleDeclarativeTest {
         Map<Class, String> rootNodeMappings = new HashMap<>();
         rootNodeMappings.put(WindowNode.class, "windowNode");
 
-        DeclarativeNodeConiguration config = new DeclarativeNodeConiguration(rootNodeMappings, class2Factory, null, factorySet);
+        DeclarativeNodeConfiguration config = new DeclarativeNodeConfiguration(rootNodeMappings, class2Factory, null, factorySet);
 
         TopologicallySortedDependecyGraph instance = new TopologicallySortedDependecyGraph(config);
         instance.generateDependencyTree();
@@ -190,7 +190,7 @@ public class SimpleDeclarativeTest {
         factorySet.add(new WindowNodeFactory());
         Map<Class, String> rootNodeMappings = new HashMap<>();
         rootNodeMappings.put(WindowNode.class, "windowNode");
-        DeclarativeNodeConiguration config = new DeclarativeNodeConiguration(rootNodeMappings, null, null, factorySet);
+        DeclarativeNodeConfiguration config = new DeclarativeNodeConfiguration(rootNodeMappings, null, null, factorySet);
         TopologicallySortedDependecyGraph instance = new TopologicallySortedDependecyGraph(config);
         instance.generateDependencyTree();
         //override the EindowNode class with DynamicallyGeneratedWindowNode

--- a/generator/src/test/java/com/fluxtion/generator/evenpublisher/EventPublisherTest.java
+++ b/generator/src/test/java/com/fluxtion/generator/evenpublisher/EventPublisherTest.java
@@ -7,7 +7,7 @@ package com.fluxtion.generator.evenpublisher;
 
 import com.fluxtion.api.annotations.EventHandler;
 import com.fluxtion.api.event.Event;
-import com.fluxtion.api.event.EventPublsher;
+import com.fluxtion.api.event.EventPublisher;
 import com.fluxtion.api.event.RegisterEventHandler;
 import com.fluxtion.generator.util.BaseSepInprocessTest;
 import java.util.concurrent.atomic.LongAdder;
@@ -25,7 +25,7 @@ public class EventPublisherTest extends BaseSepInprocessTest {
     public void testAudit() {
         sep((c) -> {
             GreaterThan gt_10 = c.addNode(new GreaterThan(10));
-            EventPublsher publisher = c.addPublicNode(new EventPublsher(), "publisher");
+            EventPublisher publisher = c.addPublicNode(new EventPublisher(), "publisher");
             publisher.addEventSource(gt_10);
             c.formatSource = true;
         });

--- a/generator/src/test/java/com/fluxtion/generator/targets/InjectedFactoryTest.java
+++ b/generator/src/test/java/com/fluxtion/generator/targets/InjectedFactoryTest.java
@@ -18,7 +18,7 @@
  */
 package com.fluxtion.generator.targets;
 
-import com.fluxtion.builder.node.DeclarativeNodeConiguration;
+import com.fluxtion.builder.node.DeclarativeNodeConfiguration;
 import com.fluxtion.builder.node.NodeFactory;
 import com.fluxtion.builder.node.SEPConfig;
 import static com.fluxtion.generator.targets.JavaGeneratorNames.test_injected_factory;
@@ -48,7 +48,7 @@ public class InjectedFactoryTest {
         //Factories
         Set<Class<? extends NodeFactory>> factoryList = new HashSet<>();
         factoryList.add(KeyProcessorFactory.class);
-        cfg.declarativeConfig = new DeclarativeNodeConiguration(null, factoryList, null);
+        cfg.declarativeConfig = new DeclarativeNodeConfiguration(null, factoryList, null);
         //generate
         JavaClass generatedClass = JavaTestGeneratorHelper.generateClass(cfg, test_injected_factory);
         assertEquals(3, generatedClass.getFields().length);
@@ -65,7 +65,7 @@ public class InjectedFactoryTest {
         Set<Class<? extends NodeFactory>> factoryList = new HashSet<>();
         factoryList.add(KeyProcessorFactory.class);
         cfg.maxFiltersInline = 10;
-        cfg.declarativeConfig = new DeclarativeNodeConiguration(null, factoryList, null);
+        cfg.declarativeConfig = new DeclarativeNodeConfiguration(null, factoryList, null);
         //generate
         JavaClass generatedClass = JavaTestGeneratorHelper.generateClass(cfg, test_injected_factory_variable_config);
         assertEquals(4, generatedClass.getFields().length);

--- a/generator/src/test/java/com/fluxtion/generator/util/BaseSepTest.java
+++ b/generator/src/test/java/com/fluxtion/generator/util/BaseSepTest.java
@@ -21,7 +21,7 @@ import com.fluxtion.api.event.Event;
 import com.fluxtion.api.lifecycle.EventHandler;
 import com.fluxtion.api.lifecycle.Lifecycle;
 import com.fluxtion.builder.generation.GenerationContext;
-import com.fluxtion.builder.node.DeclarativeNodeConiguration;
+import com.fluxtion.builder.node.DeclarativeNodeConfiguration;
 import com.fluxtion.builder.node.NodeFactory;
 import com.fluxtion.builder.node.SEPConfig;
 import com.fluxtion.generator.compiler.SepCompilerConfig;
@@ -88,10 +88,10 @@ public class BaseSepTest {
         }
     }
 
-    public static DeclarativeNodeConiguration factorySet(Class<? extends NodeFactory>... classes) {
+    public static DeclarativeNodeConfiguration factorySet(Class<? extends NodeFactory>... classes) {
         Set<Class<? extends NodeFactory>> factoryList = new HashSet<>();
         factoryList.addAll(Arrays.asList(classes));
-        DeclarativeNodeConiguration declarativeConfig = new DeclarativeNodeConiguration(null, factoryList, null);
+        DeclarativeNodeConfiguration declarativeConfig = new DeclarativeNodeConfiguration(null, factoryList, null);
         return declarativeConfig;
     }
 

--- a/generator/src/test/java/com/fluxtion/test/nodegen/AveragingNodeFactoryTest.java
+++ b/generator/src/test/java/com/fluxtion/test/nodegen/AveragingNodeFactoryTest.java
@@ -17,7 +17,7 @@
  */
 package com.fluxtion.test.nodegen;
 
-import com.fluxtion.builder.node.DeclarativeNodeConiguration;
+import com.fluxtion.builder.node.DeclarativeNodeConfiguration;
 import com.fluxtion.builder.node.SEPConfig;
 import com.fluxtion.builder.node.NodeFactory;
 import com.fluxtion.builder.generation.GenerationContext;
@@ -79,7 +79,7 @@ public class AveragingNodeFactoryTest extends BaseSepTest {
             Map<Class, String> rootNodeMappings = new HashMap<>();
             rootNodeMappings.put(AveragingNode.class, "averagingNode");
 
-            declarativeConfig = new DeclarativeNodeConiguration(rootNodeMappings, factoryList, config);
+            declarativeConfig = new DeclarativeNodeConfiguration(rootNodeMappings, factoryList, config);
 
         }
     }


### PR DESCRIPTION
`EventPublsher` => `EventPublisher` 
`DeclarativeNodeConiguration` => `DeclarativeNodeConfiguration`

This might be a breaking change if someone uses an `EventPublsher` directly though