### PR TITLE
fix: refactor some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Thanks for dropping by, hope we can persuade you to donate your time to investig
 
 Fluxtion is a fully featured java based event stream processor that brings real-time data processing inside your application. If you need to build applications that react to complex events and make fast decisions then Fluxtion is for you. We build stream processing logic free from any messaging layer, there is no lock-in with Fluxtion.
 
-Fluxtion is is easy to use and ultra fast, our sweet spot is either edge processing or single server applications. Whether you need to process tens of millions of events per second or write complex rule driven applications that make decisions in microseconds we can help. Retro fitting real-time calculations into an existing application without requiring wholesale changes to the infrastructure is a great fit. When you need to make decisions and not just calculate then you are in the right place.
+Fluxtion is easy to use and ultra fast, our sweet spot is either edge processing or single server applications. Whether you need to process tens of millions of events per second or write complex rule driven applications that make decisions in microseconds we can help. Retro fitting real-time calculations into an existing application without requiring wholesale changes to the infrastructure is a great fit. When you need to make decisions and not just calculate then you are in the right place.
 
 Uniquely among stream processors Fluxtion employs ahead of time compilation to create a stream processing engine. Describe your processing and Fluxtion tailors a solution to your needs at build time. Ahead of time compilation offers several critical advantages over existing products, 
  - Ultra fast [sub-microsecond response times](http://fluxtion.com/solutions/high-performance-flight-analysis/)
@@ -55,14 +55,14 @@ Uniquely among stream processors Fluxtion employs ahead of time compilation to c
  - Source code is generated that makes debugging and maintenance easy
  - Meta-data such as images and graphml are created to visualise the process graph
 ## Example
-We have a five minute tutorial to dive into [here](https://github.com/v12technology/fluxtion-quickstart/tree/master).  A client written instance that controls an external system is integrated directly into the generated processor. 
+We have a five-minute tutorial to dive into [here](https://github.com/v12technology/fluxtion-quickstart/tree/master).  A client written instance that controls an external system is integrated directly into the generated processor. 
 ## Philosophy
 Our philosophy is to make delivering streaming applications in java simple by employing a clean modern api similar to the familiar Java streams api. The Fluxtion compiler carries the burden of generating simple efficient code that is optimised for your specific application. We pay the cost at compile time only once, so every execution of your stream processor sees benefits in reduced startup time and smaller running costs.
 
 Why concentrate solely on the processing logic? There are many great messaging systems out there offering scale out to hundreds of millions of events per second. But many reactive applications do not need that scale, the problem is integrating the event streams from different messaging systems into a single decision making engine. In cases like these you want to concentrate on writing the logic. 
 ## Highlights
 ### Ahead of time compiler
-Fluxtion constructs a model of the stream processor and generates a set of java classes that meet the requirement. The compiled code is highly optimised for memory and cpu. Small, compact and jit friendly flxution stream processors get the best out of the JVM, giving unbeatable performance. 
+Fluxtion constructs a model of the stream processor and generates a set of java classes that meet the requirement. The compiled code is highly optimised for memory and cpu. Small, compact and jit friendly fluxtion stream processors get the best out of the JVM, giving unbeatable performance. 
 ### Pipeline vs graph processing
 Fluxtion is built as a graph processor and not a pipeline. A pipeline has a single entry point and single execution path, a graph processor has multiple entry points multiple execution paths. Handling heterogeneous event types in a unique fashion is the default behaviour. In fact the more complex the problem the greater the advantage that Fluxtion displays. 
 ### Integrating with client code

--- a/builder/src/main/java/com/fluxtion/builder/node/DeclarativeNodeConfiguration.java
+++ b/builder/src/main/java/com/fluxtion/builder/node/DeclarativeNodeConfiguration.java
@@ -28,7 +28,7 @@ import java.util.Set;
  * <h2>Doc to be completed</h2>
  * @author Greg Higgins
  */
-public final class DeclarativeNodeConiguration {
+public final class DeclarativeNodeConfiguration {
 
     /**
      * The root nodes to create and the variable names they should be mapped to.
@@ -63,7 +63,7 @@ public final class DeclarativeNodeConiguration {
      */
     public final Map config;
 
-    public DeclarativeNodeConiguration(Map<Class, String> rootNodeMappings, Set<Class<? extends NodeFactory>> factoryList, Map config) {
+    public DeclarativeNodeConfiguration(Map<Class, String> rootNodeMappings, Set<Class<? extends NodeFactory>> factoryList, Map config) {
         this(rootNodeMappings, factoryList, config, null);
     }
 
@@ -75,7 +75,7 @@ public final class DeclarativeNodeConiguration {
      * @param factorySet 
      */
     @SuppressWarnings("unchecked")
-    public DeclarativeNodeConiguration(Map<Class, String> rootNodeMappings, Set<Class<? extends NodeFactory>> factoryList, Map config, Set<NodeFactory<?>> factorySet) {
+    public DeclarativeNodeConfiguration(Map<Class, String> rootNodeMappings, Set<Class<? extends NodeFactory>> factoryList, Map config, Set<NodeFactory<?>> factorySet) {
         this.rootNodeMappings = rootNodeMappings == null ? Collections.EMPTY_MAP : rootNodeMappings;
         this.factoryClassSet = factoryList == null ? new HashSet<>() : factoryList;
         this.factorySet = factorySet == null ? new HashSet<>() : factorySet;
@@ -101,7 +101,7 @@ public final class DeclarativeNodeConiguration {
         if (getClass() != obj.getClass()) {
             return false;
         }
-        final DeclarativeNodeConiguration other = (DeclarativeNodeConiguration) obj;
+        final DeclarativeNodeConfiguration other = (DeclarativeNodeConfiguration) obj;
         if (!Objects.equals(this.rootNodeMappings, other.rootNodeMappings)) {
             return false;
         }

--- a/builder/src/main/java/com/fluxtion/builder/node/SEPConfig.java
+++ b/builder/src/main/java/com/fluxtion/builder/node/SEPConfig.java
@@ -186,7 +186,7 @@ public class SEPConfig {
     /**
      * Node Factory configuration
      */
-    public DeclarativeNodeConiguration declarativeConfig;
+    public DeclarativeNodeConfiguration declarativeConfig;
 
     //MAPPING
     /**

--- a/examples/documentation-examples/src/main/java/com/fluxtion/example/core/events/collections/Aggregator.java
+++ b/examples/documentation-examples/src/main/java/com/fluxtion/example/core/events/collections/Aggregator.java
@@ -35,12 +35,12 @@ public class Aggregator {
     }
 
     @OnParentUpdate("handlers")
-    public void parentUdated(Object parent) {
+    public void parentUpdated(Object parent) {
 
     }
 
     @OnParentUpdate
-    public void parentCfgUdated(ConfigHandler parent) {
+    public void parentCfgUpdated(ConfigHandler parent) {
 
     }
     

--- a/examples/documentation-examples/src/main/java/com/fluxtion/example/core/events/collections/generated/SampleProcessor.java
+++ b/examples/documentation-examples/src/main/java/com/fluxtion/example/core/events/collections/generated/SampleProcessor.java
@@ -90,17 +90,17 @@ public class SampleProcessor implements StaticEventProcessor, BatchHandler, Life
     isDirty_configHandler_7 = true;
     configHandler_7.cfgUpdate(typedEvent);
     if (isDirty_configHandler_7) {
-      aggregator_13.parentUdated(configHandler_7);
+      aggregator_13.parentUpdated(configHandler_7);
     }
     isDirty_configHandler_9 = true;
     configHandler_9.cfgUpdate(typedEvent);
     if (isDirty_configHandler_9) {
-      aggregator_13.parentCfgUdated(configHandler_9);
+      aggregator_13.parentCfgUpdated(configHandler_9);
     }
     isDirty_configHandler_11 = true;
     configHandler_11.cfgUpdate(typedEvent);
     if (isDirty_configHandler_11) {
-      aggregator_13.parentCfgUdated(configHandler_11);
+      aggregator_13.parentCfgUpdated(configHandler_11);
     }
     if (isDirty_configHandler_7
         | isDirty_configHandler_9
@@ -119,7 +119,7 @@ public class SampleProcessor implements StaticEventProcessor, BatchHandler, Life
     isDirty_dataEventHandler_5 = true;
     dataEventHandler_5.handleEvent(typedEvent);
     if (isDirty_dataEventHandler_5) {
-      aggregator_13.parentUdated(dataEventHandler_5);
+      aggregator_13.parentUpdated(dataEventHandler_5);
     }
     if (isDirty_configHandler_7
         | isDirty_configHandler_9
@@ -138,12 +138,12 @@ public class SampleProcessor implements StaticEventProcessor, BatchHandler, Life
     isDirty_myEventHandler_1 = true;
     myEventHandler_1.handleEvent(typedEvent);
     if (isDirty_myEventHandler_1) {
-      aggregator_13.parentUdated(myEventHandler_1);
+      aggregator_13.parentUpdated(myEventHandler_1);
     }
     isDirty_myEventHandler_3 = true;
     myEventHandler_3.handleEvent(typedEvent);
     if (isDirty_myEventHandler_3) {
-      aggregator_13.parentUdated(myEventHandler_3);
+      aggregator_13.parentUpdated(myEventHandler_3);
     }
     if (isDirty_configHandler_7
         | isDirty_configHandler_9

--- a/examples/documentation-examples/src/main/resources/XXlogback.xml
+++ b/examples/documentation-examples/src/main/resources/XXlogback.xml
@@ -26,7 +26,7 @@ along with this program.  If not, see
     </encoder>
   </appender>
   <logger name="org.reflections.Reflections" level="warn"/>
-  <logger name="com.fluxtion.generator.model.TopologicallySortedDependecyGraph" level="info"/>
+  <logger name="com.fluxtion.generator.model.TopologicallySortedDependencyGraph" level="info"/>
 
   <root level="info">
     <appender-ref ref="STDOUT" />

--- a/examples/futext-examples/src/main/java/com/fluxtion/ext/futext/example/flightdelay/generated/CalculationStateGroupBy_4.java
+++ b/examples/futext-examples/src/main/java/com/fluxtion/ext/futext/example/flightdelay/generated/CalculationStateGroupBy_4.java
@@ -1,27 +1,10 @@
 package com.fluxtion.ext.futext.example.flightdelay.generated;
 
-import com.fluxtion.api.SepContext;
-import com.fluxtion.api.annotations.EventHandler;
-import com.fluxtion.api.annotations.Initialise;
-import com.fluxtion.api.annotations.NoEventReference;
-import com.fluxtion.api.annotations.OnEvent;
-import com.fluxtion.api.annotations.OnEventComplete;
-import com.fluxtion.api.annotations.OnParentUpdate;
 import com.fluxtion.ext.futext.example.flightdelay.CarrierDelay;
-import com.fluxtion.ext.futext.example.flightdelay.FlightDetails;
-import com.fluxtion.ext.futext.example.flightdelay.generated.Filter_getDelay_By_positiveInt0;
-import com.fluxtion.ext.streaming.api.ArrayListWrappedCollection;
-import com.fluxtion.ext.streaming.api.WrappedCollection;
 import com.fluxtion.ext.streaming.api.Wrapper;
 import com.fluxtion.ext.streaming.api.group.AggregateFunctions.AggregateAverage;
-import com.fluxtion.ext.streaming.api.group.AggregateFunctions.AggregateCount;
-import com.fluxtion.ext.streaming.api.group.AggregateFunctions.AggregateSum;
-import com.fluxtion.ext.streaming.api.group.GroupBy;
-import com.fluxtion.ext.streaming.api.group.GroupByIniitialiser;
-import com.fluxtion.ext.streaming.api.group.GroupByTargetMap;
+import com.fluxtion.ext.streaming.api.group.GroupByInitializer;
 import java.util.BitSet;
-import java.util.Collection;
-import java.util.Map;
 
 /**
  * generated group by calculation state holder. This class holds the state of a group by
@@ -56,7 +39,7 @@ public final class CalculationStateGroupBy_4 implements Wrapper<CarrierDelay> {
    * @param source
    * @return The first time this is a complete record is processed
    */
-  public boolean processSource(int index, GroupByIniitialiser initialiser, Object source) {
+  public boolean processSource(int index, GroupByInitializer initialiser, Object source) {
     boolean prevMatched = allMatched();
     if (!updateMap.get(index)) {
       initialiser.apply(source, target);

--- a/examples/futext-examples/src/main/java/com/fluxtion/ext/futext/example/flightdelay/generated/GroupBy_4.java
+++ b/examples/futext-examples/src/main/java/com/fluxtion/ext/futext/example/flightdelay/generated/GroupBy_4.java
@@ -1,25 +1,18 @@
 package com.fluxtion.ext.futext.example.flightdelay.generated;
 
-import com.fluxtion.api.SepContext;
-import com.fluxtion.api.annotations.EventHandler;
 import com.fluxtion.api.annotations.Initialise;
 import com.fluxtion.api.annotations.NoEventReference;
 import com.fluxtion.api.annotations.OnEvent;
-import com.fluxtion.api.annotations.OnEventComplete;
 import com.fluxtion.api.annotations.OnParentUpdate;
 import com.fluxtion.ext.futext.example.flightdelay.CarrierDelay;
 import com.fluxtion.ext.futext.example.flightdelay.FlightDetails;
-import com.fluxtion.ext.futext.example.flightdelay.generated.Filter_getDelay_By_positiveInt0;
 import com.fluxtion.ext.streaming.api.ArrayListWrappedCollection;
-import com.fluxtion.ext.streaming.api.WrappedCollection;
 import com.fluxtion.ext.streaming.api.Wrapper;
-import com.fluxtion.ext.streaming.api.group.AggregateFunctions.AggregateAverage;
 import com.fluxtion.ext.streaming.api.group.AggregateFunctions.AggregateCount;
 import com.fluxtion.ext.streaming.api.group.AggregateFunctions.AggregateSum;
 import com.fluxtion.ext.streaming.api.group.GroupBy;
-import com.fluxtion.ext.streaming.api.group.GroupByIniitialiser;
+import com.fluxtion.ext.streaming.api.group.GroupByInitializer;
 import com.fluxtion.ext.streaming.api.group.GroupByTargetMap;
-import java.util.BitSet;
 import java.util.Collection;
 import java.util.Map;
 
@@ -38,7 +31,7 @@ public final class GroupBy_4 implements GroupBy<CarrierDelay> {
   public Filter_getDelay_By_positiveInt0 filter_getDelay_By_positiveInt00;
   private CarrierDelay target;
   private GroupByTargetMap<String, CarrierDelay, CalculationStateGroupBy_4> calcState;
-  private GroupByIniitialiser<FlightDetails, CarrierDelay>
+  private GroupByInitializer<FlightDetails, CarrierDelay>
       initialiserfilter_getDelay_By_positiveInt00;
 
   @OnParentUpdate("filter_getDelay_By_positiveInt00")
@@ -90,7 +83,7 @@ public final class GroupBy_4 implements GroupBy<CarrierDelay> {
     allMatched = false;
     target = null;
     initialiserfilter_getDelay_By_positiveInt00 =
-        new GroupByIniitialiser<FlightDetails, CarrierDelay>() {
+        new GroupByInitializer<FlightDetails, CarrierDelay>() {
 
           @Override
           public void apply(FlightDetails source, CarrierDelay target) {

--- a/extensions/streaming/api/src/main/java/com/fluxtion/ext/streaming/api/group/GroupByInitializer.java
+++ b/extensions/streaming/api/src/main/java/com/fluxtion/ext/streaming/api/group/GroupByInitializer.java
@@ -23,7 +23,7 @@ package com.fluxtion.ext.streaming.api.group;
  * @param <S> Source type of group by
  * @param <T> Target type of group by
  */
-public interface GroupByIniitialiser<S, T> {
+public interface GroupByInitializer<S, T> {
     
     void apply(S source, T target);
     

--- a/extensions/streaming/api/src/main/java/com/fluxtion/ext/streaming/api/group/GroupByTargetMap.java
+++ b/extensions/streaming/api/src/main/java/com/fluxtion/ext/streaming/api/group/GroupByTargetMap.java
@@ -41,7 +41,7 @@ public class GroupByTargetMap<K, U, T extends Wrapper<U>> {
     }
 
     //TODO add methods for Numeric value, and primitive types
-    public T getOrCreateInstance(Object key, GroupByIniitialiser<K, U> initialiser, K source) {
+    public T getOrCreateInstance(Object key, GroupByInitializer<K, U> initialiser, K source) {
         T instance = map.get(key);
         if (instance == null) {
             try {
@@ -97,7 +97,7 @@ public class GroupByTargetMap<K, U, T extends Wrapper<U>> {
         return instance;
     }
 
-    public T getOrCreateInstance(CharSequence key, GroupByIniitialiser<K, U> initialiser, K source) {
+    public T getOrCreateInstance(CharSequence key, GroupByInitializer<K, U> initialiser, K source) {
         String keyString = key.toString();
         T instance = map.get(keyString);
         if (instance == null) {
@@ -112,7 +112,7 @@ public class GroupByTargetMap<K, U, T extends Wrapper<U>> {
         return instance;
     }
 
-    public T getOrCreateInstance(BufferValue key, GroupByIniitialiser<K, U> initialiser, K source) {
+    public T getOrCreateInstance(BufferValue key, GroupByInitializer<K, U> initialiser, K source) {
         T instance = map.get(key.asString());
         if (instance == null) {
             try {
@@ -126,7 +126,7 @@ public class GroupByTargetMap<K, U, T extends Wrapper<U>> {
         return instance;
     }
 
-    public T getOrCreateInstance(MultiKey<K> key, GroupByIniitialiser<K, U> initialiser, K source) {
+    public T getOrCreateInstance(MultiKey<K> key, GroupByInitializer<K, U> initialiser, K source) {
         T instance = map.get(key);
         if (instance == null) {
             try {

--- a/extensions/streaming/builder/src/main/java/com/fluxtion/ext/streaming/builder/group/GroupByContext.java
+++ b/extensions/streaming/builder/src/main/java/com/fluxtion/ext/streaming/builder/group/GroupByContext.java
@@ -29,7 +29,7 @@ import com.fluxtion.ext.streaming.api.ArrayListWrappedCollection;
 import com.fluxtion.ext.streaming.api.WrappedCollection;
 import com.fluxtion.ext.streaming.api.Wrapper;
 import com.fluxtion.ext.streaming.api.group.GroupBy;
-import com.fluxtion.ext.streaming.api.group.GroupByIniitialiser;
+import com.fluxtion.ext.streaming.api.group.GroupByInitializer;
 import com.fluxtion.ext.streaming.api.group.GroupByTargetMap;
 import com.fluxtion.ext.streaming.builder.Templates;
 import com.fluxtion.ext.streaming.builder.util.FunctionGeneratorHelper;
@@ -79,7 +79,7 @@ public class GroupByContext<K, T> {
     final ImportMap importMap = ImportMap.newMap(Initialise.class, OnEvent.class,
             Wrapper.class, OnParentUpdate.class, OnEventComplete.class,
             Map.class, BitSet.class, GroupBy.class, EventHandler.class,
-            GroupByIniitialiser.class, GroupByTargetMap.class, NoEventReference.class,
+            GroupByInitializer.class, GroupByTargetMap.class, NoEventReference.class,
             WrappedCollection.class,Collection.class,
             ArrayListWrappedCollection.class, SepContext.class
     );

--- a/extensions/text/api/src/main/java/com/fluxtion/ext/text/api/util/EventPublisher.java
+++ b/extensions/text/api/src/main/java/com/fluxtion/ext/text/api/util/EventPublisher.java
@@ -30,7 +30,7 @@ import java.util.Arrays;
  *
  * @author V12 Technology Ltd.
  */
-public class EventPublsher<T> {
+public class EventPublisher<T> {
 
     private Wrapper<T>[] wrapperSource;
     private Wrapper<T>[] validatedSource;
@@ -38,7 +38,7 @@ public class EventPublsher<T> {
     private StaticEventProcessor[] handlers;
     public boolean publishOnValidate = false;
 
-    public EventPublsher() {
+    public EventPublisher() {
         init();
     }
 
@@ -138,7 +138,7 @@ public class EventPublsher<T> {
         if (getClass() != obj.getClass()) {
             return false;
         }
-        final EventPublsher<?> other = (EventPublsher<?>) obj;
+        final EventPublisher<?> other = (EventPublisher<?>) obj;
         if (!Arrays.deepEquals(this.wrapperSource, other.wrapperSource)) {
             return false;
         }

--- a/extensions/text/api/src/main/java/com/fluxtion/ext/text/api/util/marshaller/CsvRecordMarshaller.java
+++ b/extensions/text/api/src/main/java/com/fluxtion/ext/text/api/util/marshaller/CsvRecordMarshaller.java
@@ -25,7 +25,7 @@ import com.fluxtion.ext.text.api.csv.ValidationLogger;
 import com.fluxtion.ext.text.api.event.CharEvent;
 import com.fluxtion.ext.text.api.event.EofEvent;
 import com.fluxtion.ext.text.api.event.RegisterEventHandler;
-import com.fluxtion.ext.text.api.util.EventPublsher;
+import com.fluxtion.ext.text.api.util.EventPublisher;
 
 /*
  * <pre>
@@ -40,7 +40,7 @@ public class CsvRecordMarshaller implements StaticEventProcessor, Lifecycle, Cha
 
     //Node declarations
     private final RowProcessor rowProcessor;
-    private final EventPublsher eventPublsher = new EventPublsher();
+    private final EventPublisher eventPublisher = new EventPublisher();
     private final ValidationLogger validationLogger = new ValidationLogger("validationLog");
     private final ValidationLogSink validationLogSink = new ValidationLogSink("validationLogSink");
     //Dirty flags
@@ -51,7 +51,7 @@ public CsvRecordMarshaller(RowProcessor rowProcessor) {
         this.rowProcessor.setErrorLog(validationLogger);
         validationLogSink.setPublishLogImmediately(true);
         validationLogger.logSink = validationLogSink;
-        eventPublsher.publishOnValidate = (boolean) false;
+        eventPublisher.publishOnValidate = false;
     }
 
     @Override
@@ -96,7 +96,7 @@ public CsvRecordMarshaller(RowProcessor rowProcessor) {
         //Default, no filter methods
         isDirty_RowProcessor = rowProcessor.charEvent(typedEvent);
         if (isDirty_RowProcessor) {
-            eventPublsher.wrapperUpdate(rowProcessor);
+            eventPublisher.wrapperUpdate(rowProcessor);
         }
         //event stack unwind callbacks
         afterEvent();
@@ -106,7 +106,7 @@ public CsvRecordMarshaller(RowProcessor rowProcessor) {
         //Default, no filter methods
         isDirty_RowProcessor = rowProcessor.eof(typedEvent);
         if (isDirty_RowProcessor) {
-            eventPublsher.wrapperUpdate(rowProcessor);
+            eventPublisher.wrapperUpdate(rowProcessor);
         }
         //event stack unwind callbacks
         afterEvent();
@@ -114,7 +114,7 @@ public CsvRecordMarshaller(RowProcessor rowProcessor) {
 
     public void handleEvent(RegisterEventHandler typedEvent) {
         //Default, no filter methods
-        eventPublsher.registerEventHandler(typedEvent);
+        eventPublisher.registerEventHandler(typedEvent);
         //event stack unwind callbacks
         afterEvent();
     }
@@ -126,7 +126,7 @@ public CsvRecordMarshaller(RowProcessor rowProcessor) {
     @Override
     public void init() {
         rowProcessor.init();
-        eventPublsher.init();
+        eventPublisher.init();
         validationLogSink.init();
     }
 

--- a/extensions/text/builder/src/main/java/com/fluxtion/ext/text/builder/csv/RecordParserBuilder.java
+++ b/extensions/text/builder/src/main/java/com/fluxtion/ext/text/builder/csv/RecordParserBuilder.java
@@ -38,7 +38,7 @@ import com.fluxtion.ext.text.api.csv.RowProcessor;
 import com.fluxtion.ext.text.api.csv.ValidationLogger;
 import com.fluxtion.ext.text.api.event.CharEvent;
 import com.fluxtion.ext.text.api.event.EofEvent;
-import com.fluxtion.ext.text.api.util.EventPublsher;
+import com.fluxtion.ext.text.api.util.EventPublisher;
 import static com.fluxtion.ext.text.builder.Templates.CSV_MARSHALLER;
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -322,7 +322,7 @@ public class RecordParserBuilder<P extends RecordParserBuilder<P, T>, T> {
             });
             GenerationContext.SINGLETON.getNodeList().add(result);
             if (addEventPublisher) {
-                EventPublsher publisher = new EventPublsher();
+                EventPublisher publisher = new EventPublisher();
                 GenerationContext.SINGLETON.addOrUseExistingNode(publisher);
                 publisher.addEventSource(result);
             }

--- a/extensions/text/builder/src/main/java/com/fluxtion/ext/text/builder/csv/RulesEvaluatorBuilder.java
+++ b/extensions/text/builder/src/main/java/com/fluxtion/ext/text/builder/csv/RulesEvaluatorBuilder.java
@@ -34,7 +34,7 @@ import com.fluxtion.ext.text.api.csv.RowExceptionNotifier;
 import com.fluxtion.ext.text.api.csv.RowProcessor;
 import com.fluxtion.ext.text.api.csv.RulesEvaluator;
 import com.fluxtion.ext.text.api.csv.ValidationLogSink.LogNotifier;
-import com.fluxtion.ext.text.api.util.EventPublsher;
+import com.fluxtion.ext.text.api.util.EventPublisher;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
@@ -105,7 +105,7 @@ public class RulesEvaluatorBuilder<T> {
                 );
             }
 
-            EventPublsher publisher = new EventPublsher();
+            EventPublisher publisher = new EventPublisher();
             publisher.addEventSource(monitoredWrapped);
             publisher = GenerationContext.SINGLETON.addOrUseExistingNode(publisher);
             publisher.addValidatedSource(evaluator.passedNotifier());
@@ -159,7 +159,7 @@ public class RulesEvaluatorBuilder<T> {
                 );
             }
 
-            EventPublsher publisher = new EventPublsher();
+            EventPublisher publisher = new EventPublisher();
             publisher.addEventSource(monitoredWrapped);
             publisher = GenerationContext.SINGLETON.addOrUseExistingNode(publisher);
             publisher.addValidatedSource(evaluator.passedNotifier());
@@ -209,7 +209,7 @@ public class RulesEvaluatorBuilder<T> {
                         filter(monitored, nand(testList.toArray()))
                 );
             }
-            EventPublsher publisher = new EventPublsher();
+            EventPublisher publisher = new EventPublisher();
             publisher.addEventSource(monitored);
             publisher = GenerationContext.SINGLETON.addOrUseExistingNode(publisher);
             publisher.addValidatedSource(evaluator.passedNotifier());

--- a/extensions/text/builder/src/test/java/com/fluxtion/ext/futext/builder/filter/TextMatchTest.java
+++ b/extensions/text/builder/src/test/java/com/fluxtion/ext/futext/builder/filter/TextMatchTest.java
@@ -17,7 +17,7 @@
 package com.fluxtion.ext.futext.builder.filter;
 
 import com.fluxtion.api.StaticEventProcessor;
-import com.fluxtion.builder.node.DeclarativeNodeConiguration;
+import com.fluxtion.builder.node.DeclarativeNodeConfiguration;
 import com.fluxtion.builder.node.NodeFactory;
 import com.fluxtion.builder.node.SEPConfig;
 import com.fluxtion.ext.futext.builder.test.helpers.TextMatchPrinter;
@@ -61,7 +61,7 @@ public class TextMatchTest extends BaseSepTest {
             addPublicNode(new TextMatchPrinter("ccypair=\"eurusd\""), MATCHER_VARIABLE_NAME);
             Set<Class<? extends NodeFactory>> factoryList = new HashSet<>();
             factoryList.add(AsciiMatchFilterFactory.class);
-            declarativeConfig = new DeclarativeNodeConiguration(null, factoryList, null);
+            declarativeConfig = new DeclarativeNodeConfiguration(null, factoryList, null);
         }
     }
 

--- a/generator/src/main/java/com/fluxtion/generator/Generator.java
+++ b/generator/src/main/java/com/fluxtion/generator/Generator.java
@@ -26,7 +26,7 @@ import static com.fluxtion.generator.Templates.JAVA_TEMPLATE;
 import static com.fluxtion.generator.Templates.JAVA_TEST_DECORATOR_TEMPLATE;
 import com.fluxtion.generator.exporter.PngGenerator;
 import com.fluxtion.generator.model.SimpleEventProcessorModel;
-import com.fluxtion.generator.model.TopologicallySortedDependecyGraph;
+import com.fluxtion.generator.model.TopologicallySortedDependencyGraph;
 import com.fluxtion.generator.targets.SepJavaSourceModelHugeFilter;
 import com.google.common.io.CharSink;
 import com.google.common.io.CharSource;
@@ -72,7 +72,7 @@ public class Generator {
         LOG.debug("start graph calc");
         GenerationContext context = GenerationContext.SINGLETON;
         //generate model
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(
                 config.nodeList,
                 config.publicNodes,
                 config.declarativeConfig,
@@ -251,7 +251,7 @@ public class Generator {
         }
     }
 
-    private void exportGraphMl(TopologicallySortedDependecyGraph graph) {
+    private void exportGraphMl(TopologicallySortedDependencyGraph graph) {
         if (config.generateDescription) {
             try {
                 LOG.debug("generating event images and graphml");

--- a/generator/src/main/java/com/fluxtion/generator/compiler/SepCompiler.java
+++ b/generator/src/main/java/com/fluxtion/generator/compiler/SepCompiler.java
@@ -20,7 +20,7 @@ package com.fluxtion.generator.compiler;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.core.util.StatusPrinter;
 import com.fluxtion.builder.generation.GenerationContext;
-import com.fluxtion.builder.node.DeclarativeNodeConiguration;
+import com.fluxtion.builder.node.DeclarativeNodeConfiguration;
 import com.fluxtion.builder.node.NodeFactory;
 import com.fluxtion.builder.node.SEPConfig;
 import com.fluxtion.generator.Generator;
@@ -157,7 +157,7 @@ public class SepCompiler {
             LOG.debug("loading SepFactoryConfigBean with beanLoader");
             SepFactoryConfigBean loadedConfig = beanLoader.loadAs(input, SepFactoryConfigBean.class);
             LOG.debug("DeclarativeNodeConiguration load");
-            DeclarativeNodeConiguration cfgActual = loadedConfig.asDeclarativeNodeConiguration();
+            DeclarativeNodeConfiguration cfgActual = loadedConfig.asDeclarativeNodeConiguration();
             LOG.debug("searching for NodeFactory's");
             Set<Class<? extends NodeFactory>> class2Factory = NodeFactoryLocator.nodeFactorySet();
             cfgActual.factoryClassSet.addAll(class2Factory);
@@ -177,7 +177,7 @@ public class SepCompiler {
                 SepFactoryConfigBean loadedConfig = new SepFactoryConfigBean();
                 loadedConfig.setRootNodeMappings(rootNodeMappings);
                 loadedConfig.setConfig(new HashMap());
-                DeclarativeNodeConiguration cfgActual = loadedConfig.asDeclarativeNodeConiguration();
+                DeclarativeNodeConfiguration cfgActual = loadedConfig.asDeclarativeNodeConiguration();
                 Set<Class<? extends NodeFactory>> class2Factory = NodeFactoryLocator.nodeFactorySet();
                 cfgActual.factoryClassSet.addAll(class2Factory);
                 builderConfig.declarativeConfig = cfgActual;
@@ -192,7 +192,7 @@ public class SepCompiler {
         SepFactoryConfigBean loadedConfig = new SepFactoryConfigBean();
         Set<Class<? extends NodeFactory>> class2Factory = NodeFactoryLocator.nodeFactorySet();
         loadedConfig.setConfig(new HashMap());
-        DeclarativeNodeConiguration cfgActual = loadedConfig.asDeclarativeNodeConiguration();
+        DeclarativeNodeConfiguration cfgActual = loadedConfig.asDeclarativeNodeConiguration();
         if (builderConfig == null || builderConfig.declarativeConfig==null) {
             cfgActual.factoryClassSet.addAll(class2Factory);
             builderConfig.declarativeConfig = cfgActual;

--- a/generator/src/main/java/com/fluxtion/generator/compiler/SepFactoryConfigBean.java
+++ b/generator/src/main/java/com/fluxtion/generator/compiler/SepFactoryConfigBean.java
@@ -18,7 +18,7 @@
 package com.fluxtion.generator.compiler;
 
 import com.fluxtion.builder.generation.GenerationContext;
-import com.fluxtion.builder.node.DeclarativeNodeConiguration;
+import com.fluxtion.builder.node.DeclarativeNodeConfiguration;
 import com.fluxtion.builder.node.NodeFactory;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -75,7 +75,7 @@ public class SepFactoryConfigBean {
         this.config = config;
     }
 
-    public DeclarativeNodeConiguration asDeclarativeNodeConiguration() throws ClassNotFoundException {
+    public DeclarativeNodeConfiguration asDeclarativeNodeConiguration() throws ClassNotFoundException {
 
         // convert rootNodeMappings to classes
         HashMap<Class, String> rootClasses = null;
@@ -110,8 +110,8 @@ public class SepFactoryConfigBean {
             }
         }
 
-        DeclarativeNodeConiguration declarativeCfg
-                = new DeclarativeNodeConiguration(rootClasses, nodeFactoryClasses, config);
+        DeclarativeNodeConfiguration declarativeCfg
+                = new DeclarativeNodeConfiguration(rootClasses, nodeFactoryClasses, config);
         return declarativeCfg;
     }
 

--- a/generator/src/main/java/com/fluxtion/generator/model/SimpleEventProcessorModel.java
+++ b/generator/src/main/java/com/fluxtion/generator/model/SimpleEventProcessorModel.java
@@ -130,7 +130,7 @@ public class SimpleEventProcessorModel {
     /**
      * The dependency model for this SEP
      */
-    private final TopologicallySortedDependecyGraph dependencyGraph;
+    private final TopologicallySortedDependencyGraph dependencyGraph;
 
     /**
      * Map of constructor argument lists for a node.
@@ -210,15 +210,15 @@ public class SimpleEventProcessorModel {
      */
     private boolean supportDirtyFiltering;
 
-    public SimpleEventProcessorModel(TopologicallySortedDependecyGraph dependencyGraph) throws Exception {
+    public SimpleEventProcessorModel(TopologicallySortedDependencyGraph dependencyGraph) throws Exception {
         this(dependencyGraph, new HashMap());
     }
 
-    public SimpleEventProcessorModel(TopologicallySortedDependecyGraph dependencyGraph, Map<Object, Integer> filterMap) throws Exception {
+    public SimpleEventProcessorModel(TopologicallySortedDependencyGraph dependencyGraph, Map<Object, Integer> filterMap) throws Exception {
         this(dependencyGraph, filterMap, null);
     }
 
-    public SimpleEventProcessorModel(TopologicallySortedDependecyGraph dependencyGraph,
+    public SimpleEventProcessorModel(TopologicallySortedDependencyGraph dependencyGraph,
             Map<Object, Integer> filterMap,
             Map<Object, String> nodeClassMap) throws Exception {
         this.dependencyGraph = dependencyGraph;

--- a/generator/src/main/java/com/fluxtion/generator/model/TopologicallySortedDependencyGraph.java
+++ b/generator/src/main/java/com/fluxtion/generator/model/TopologicallySortedDependencyGraph.java
@@ -27,7 +27,7 @@ import com.fluxtion.api.audit.Auditor;
 import com.fluxtion.api.event.Event;
 import com.fluxtion.builder.generation.GenerationContext;
 import com.fluxtion.builder.generation.NodeNameProducer;
-import com.fluxtion.builder.node.DeclarativeNodeConiguration;
+import com.fluxtion.builder.node.DeclarativeNodeConfiguration;
 import com.fluxtion.builder.node.NodeFactory;
 import com.fluxtion.builder.node.NodeRegistry;
 import com.fluxtion.builder.node.SEPConfig;
@@ -73,13 +73,13 @@ import org.xml.sax.SAXException;
  *
  * @author Greg Higgins
  */
-public class TopologicallySortedDependecyGraph implements NodeRegistry {
+public class TopologicallySortedDependencyGraph implements NodeRegistry {
 
     //TODO move this to constructor
     private Map<String, Auditor> registrationListenerMap;
 
     //TODO check there are no variable name clashes
-    private final Logger LOGGER = LoggerFactory.getLogger(TopologicallySortedDependecyGraph.class);
+    private final Logger LOGGER = LoggerFactory.getLogger(TopologicallySortedDependencyGraph.class);
     private BiMap<Object, String> inst2Name;
     private final BiMap<Object, String> inst2NameTemp;
     private final SimpleDirectedGraph<Object, DefaultEdge> graph = new SimpleDirectedGraph<>(DefaultEdge.class);
@@ -89,34 +89,34 @@ public class TopologicallySortedDependecyGraph implements NodeRegistry {
     private boolean processed = false;
     private int count;
 //    private static final int MAX_NAME_TRIES = 10000;
-    private final DeclarativeNodeConiguration declarativeNodeConiguration;
+    private final DeclarativeNodeConfiguration declarativeNodeConfiguration;
     private final HashMap<Class, CbMethodHandle> class2FactoryMethod;
     private final List publicNodeList;
     private final GenerationContext generationContext;
     private NodeNameProducer nameStrategy;
     private final SEPConfig config;
 
-    public TopologicallySortedDependecyGraph(Object... obj) {
+    public TopologicallySortedDependencyGraph(Object... obj) {
         this(Arrays.asList(obj));
     }
 
-    public TopologicallySortedDependecyGraph(List nodes) {
+    public TopologicallySortedDependencyGraph(List nodes) {
         this(nodes, null, null, null, null, null);
     }
 
-    public TopologicallySortedDependecyGraph(Map<Object, String> publicNodes) {
+    public TopologicallySortedDependencyGraph(Map<Object, String> publicNodes) {
         this(null, publicNodes, null, null, null, null);
     }
 
-    public TopologicallySortedDependecyGraph(DeclarativeNodeConiguration declarativeNodeConiguration) {
-        this(null, null, declarativeNodeConiguration, null, null, null);
+    public TopologicallySortedDependencyGraph(DeclarativeNodeConfiguration declarativeNodeConfiguration) {
+        this(null, null, declarativeNodeConfiguration, null, null, null);
     }
 
-    public TopologicallySortedDependecyGraph(List nodes, Map<Object, String> publicNodes) {
+    public TopologicallySortedDependencyGraph(List nodes, Map<Object, String> publicNodes) {
         this(nodes, publicNodes, null, null, null, null);
     }
 
-    public TopologicallySortedDependecyGraph(SEPConfig config) {
+    public TopologicallySortedDependencyGraph(SEPConfig config) {
         this(config.nodeList,
                 config.publicNodes,
                 config.declarativeConfig,
@@ -132,15 +132,15 @@ public class TopologicallySortedDependecyGraph implements NodeRegistry {
      * @param publicNodes Map of public available instances, the value is the
      * unique name of each instance. The names will override existing instances
      * in the nodes List or add the node to the set.
-     * @param declarativeNodeConiguration factory description
+     * @param declarativeNodeConfiguration factory description
      * @param strat NodeNameProducer strategy
      * @param context Generation context for this cycle
      * @param auditorMap Auditors to inject
      * @param config Config for this generation cycle
      *
      */
-    public TopologicallySortedDependecyGraph(List nodes, Map<Object, String> publicNodes,
-            DeclarativeNodeConiguration declarativeNodeConiguration,
+    public TopologicallySortedDependencyGraph(List nodes, Map<Object, String> publicNodes,
+            DeclarativeNodeConfiguration declarativeNodeConfiguration,
             GenerationContext context, Map<String, Auditor> auditorMap, SEPConfig config) {
         this.config = config;
         this.nameStrategy = new NamingStrategy();
@@ -184,7 +184,7 @@ public class TopologicallySortedDependecyGraph implements NodeRegistry {
         });
         //declaritive nodes - add arguments to method and make defensive copy 
 //        declarativeNodeMap = new HashMap<>();
-        this.declarativeNodeConiguration = declarativeNodeConiguration;
+        this.declarativeNodeConfiguration = declarativeNodeConfiguration;
         this.generationContext = context;
     }
 
@@ -493,7 +493,7 @@ public class TopologicallySortedDependecyGraph implements NodeRegistry {
             return;
         }
 
-        if (declarativeNodeConiguration != null) {
+        if (declarativeNodeConfiguration != null) {
 
             /**
              * TODO create the NodeBuilder, passing this in as a reference loop
@@ -503,17 +503,17 @@ public class TopologicallySortedDependecyGraph implements NodeRegistry {
              *
              */
             //store the factory callbacks
-            for (Class<? extends NodeFactory> clazz : declarativeNodeConiguration.factoryClassSet) {
+            for (Class<? extends NodeFactory> clazz : declarativeNodeConfiguration.factoryClassSet) {
                 NodeFactory factory = clazz.newInstance();
                 registerNodeFactory(factory);
             }
             //override any any classes with pre-initialised NodeFactories
-            for (NodeFactory factory : declarativeNodeConiguration.factorySet) {
+            for (NodeFactory factory : declarativeNodeConfiguration.factorySet) {
                 registerNodeFactory(factory);
             }
             //loop through root instance and 
-            for (Map.Entry<Class, String> rootNode : declarativeNodeConiguration.rootNodeMappings.entrySet()) {
-                Object newNode = findOrCreateNode(rootNode.getKey(), declarativeNodeConiguration.config, rootNode.getValue());
+            for (Map.Entry<Class, String> rootNode : declarativeNodeConfiguration.rootNodeMappings.entrySet()) {
+                Object newNode = findOrCreateNode(rootNode.getKey(), declarativeNodeConfiguration.config, rootNode.getValue());
                 publicNodeList.add(newNode);
             }
         }

--- a/generator/src/test/java/com/fluxtion/generator/declarative/SimpleDeclarativeTest.java
+++ b/generator/src/test/java/com/fluxtion/generator/declarative/SimpleDeclarativeTest.java
@@ -18,14 +18,14 @@
 package com.fluxtion.generator.declarative;
 
 import com.fluxtion.builder.generation.GenerationContext;
-import com.fluxtion.builder.node.DeclarativeNodeConiguration;
+import com.fluxtion.builder.node.DeclarativeNodeConfiguration;
 import com.fluxtion.builder.node.NodeFactory;
 import com.fluxtion.builder.node.SEPConfig;
 import com.fluxtion.generator.Generator;
 import com.fluxtion.generator.graphbuilder.NodeFactoryLocator;
 import com.fluxtion.generator.model.Field;
 import com.fluxtion.generator.model.SimpleEventProcessorModel;
-import com.fluxtion.generator.model.TopologicallySortedDependecyGraph;
+import com.fluxtion.generator.model.TopologicallySortedDependencyGraph;
 import com.fluxtion.generator.targets.SepJavaSourceModelHugeFilter;
 import com.fluxtion.test.nodes.Calculator;
 import com.fluxtion.test.nodes.CalculatorRegisteringAccumulatorFactory;
@@ -69,9 +69,9 @@ public class SimpleDeclarativeTest {
         Map<Class, String> rootNodeMappings = new HashMap<>();
         rootNodeMappings.put(KeyProcessorHistogram.class, "histogram");
 
-        DeclarativeNodeConiguration config = new DeclarativeNodeConiguration(rootNodeMappings, class2Factory, new HashMap<>());
+        DeclarativeNodeConfiguration config = new DeclarativeNodeConfiguration(rootNodeMappings, class2Factory, new HashMap<>());
 
-        TopologicallySortedDependecyGraph instance = new TopologicallySortedDependecyGraph(config);
+        TopologicallySortedDependencyGraph instance = new TopologicallySortedDependencyGraph(config);
         instance.generateDependencyTree();
     }
 
@@ -83,7 +83,7 @@ public class SimpleDeclarativeTest {
         rootNodeMappings.put(Calculator.class, "calculator");
         GenerationContext.setupStaticContext("com.fluxtion.test.template.java", "SimpleCalculator", new File("target/generated-test-sources/java/"), new File("target/generated-test-sources/resources/"));
 
-        DeclarativeNodeConiguration config = new DeclarativeNodeConiguration(rootNodeMappings, class2Factory, new HashMap<>());
+        DeclarativeNodeConfiguration config = new DeclarativeNodeConfiguration(rootNodeMappings, class2Factory, new HashMap<>());
         SEPConfig cfg = new SEPConfig();
         cfg.templateFile = "javaTemplate.vsl";
         cfg.declarativeConfig = config;
@@ -106,9 +106,9 @@ public class SimpleDeclarativeTest {
         Map<Class, String> rootNodeMappings = new HashMap<>();
         rootNodeMappings.put(WindowNode.class, "windowNode");
 
-        DeclarativeNodeConiguration config = new DeclarativeNodeConiguration(rootNodeMappings, class2Factory, null, factorySet);
+        DeclarativeNodeConfiguration config = new DeclarativeNodeConfiguration(rootNodeMappings, class2Factory, null, factorySet);
 
-        TopologicallySortedDependecyGraph instance = new TopologicallySortedDependecyGraph(config);
+        TopologicallySortedDependencyGraph instance = new TopologicallySortedDependencyGraph(config);
         instance.generateDependencyTree();
 
         assertEquals(1, instance.getInstanceMap().size());
@@ -126,9 +126,9 @@ public class SimpleDeclarativeTest {
         Map<Class, String> rootNodeMappings = new HashMap<>();
         rootNodeMappings.put(Calculator.class, "calcInjecting");
 
-        DeclarativeNodeConiguration config = new DeclarativeNodeConiguration(rootNodeMappings, class2Factory, null, factorySet);
+        DeclarativeNodeConfiguration config = new DeclarativeNodeConfiguration(rootNodeMappings, class2Factory, null, factorySet);
 
-        TopologicallySortedDependecyGraph instance = new TopologicallySortedDependecyGraph(config);
+        TopologicallySortedDependencyGraph instance = new TopologicallySortedDependencyGraph(config);
         instance.generateDependencyTree();
 
         assertEquals(2, instance.getInstanceMap().size());
@@ -149,9 +149,9 @@ public class SimpleDeclarativeTest {
         Map<Class, String> rootNodeMappings = new HashMap<>();
         rootNodeMappings.put(WindowNode.class, "windowNode");
 
-        DeclarativeNodeConiguration config = new DeclarativeNodeConiguration(rootNodeMappings, class2Factory, null, factorySet);
+        DeclarativeNodeConfiguration config = new DeclarativeNodeConfiguration(rootNodeMappings, class2Factory, null, factorySet);
 
-        TopologicallySortedDependecyGraph instance = new TopologicallySortedDependecyGraph(config);
+        TopologicallySortedDependencyGraph instance = new TopologicallySortedDependencyGraph(config);
         instance.generateDependencyTree();
 
         Object x = instance.getSortedDependents().get(0);
@@ -175,9 +175,9 @@ public class SimpleDeclarativeTest {
         Map<Class, String> rootNodeMappings = new HashMap<>();
         rootNodeMappings.put(WindowNode.class, "windowNode");
 
-        DeclarativeNodeConiguration config = new DeclarativeNodeConiguration(rootNodeMappings, class2Factory, null, factorySet);
+        DeclarativeNodeConfiguration config = new DeclarativeNodeConfiguration(rootNodeMappings, class2Factory, null, factorySet);
 
-        TopologicallySortedDependecyGraph instance = new TopologicallySortedDependecyGraph(config);
+        TopologicallySortedDependencyGraph instance = new TopologicallySortedDependencyGraph(config);
         instance.generateDependencyTree();
 
     }
@@ -189,8 +189,8 @@ public class SimpleDeclarativeTest {
         factorySet.add(new WindowNodeFactory());
         Map<Class, String> rootNodeMappings = new HashMap<>();
         rootNodeMappings.put(WindowNode.class, "windowNode");
-        DeclarativeNodeConiguration config = new DeclarativeNodeConiguration(rootNodeMappings, null, null, factorySet);
-        TopologicallySortedDependecyGraph instance = new TopologicallySortedDependecyGraph(config);
+        DeclarativeNodeConfiguration config = new DeclarativeNodeConfiguration(rootNodeMappings, null, null, factorySet);
+        TopologicallySortedDependencyGraph instance = new TopologicallySortedDependencyGraph(config);
         instance.generateDependencyTree();
         //override the EindowNode class with DynamicallyGeneratedWindowNode
         Object x = instance.getSortedDependents().get(0);

--- a/generator/src/test/java/com/fluxtion/generator/model/DirtyFilteringTest.java
+++ b/generator/src/test/java/com/fluxtion/generator/model/DirtyFilteringTest.java
@@ -60,7 +60,7 @@ public class DirtyFilteringTest {
 
         List<Object> nodeList = Arrays.asList(eRoot, e1, e2, dirty_1, dirty_2, dirty_3, i1, i2, i3);
         //generate model
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(nodeList);
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(nodeList);
         SimpleEventProcessorModel sep = new SimpleEventProcessorModel(graph);
         sep.generateMetaModel(true);
         //
@@ -141,7 +141,7 @@ public class DirtyFilteringTest {
                 dirty_1, dirty_2,
                 i1, i2, i3, i4, i5, i6);
         //generate model
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(nodeList);
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(nodeList);
         SimpleEventProcessorModel sep = new SimpleEventProcessorModel(graph);
         sep.generateMetaModel(true);
 
@@ -160,7 +160,7 @@ public class DirtyFilteringTest {
         DirtyNotifierNode dirty_1 = new DirtyNotifierNode("dirty_1", eh);
         
         //generate model
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(Arrays.asList(eh, dirty_1));
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(Arrays.asList(eh, dirty_1));
         SimpleEventProcessorModel sep = new SimpleEventProcessorModel(graph);
         sep.generateMetaModel(true);
         

--- a/generator/src/test/java/com/fluxtion/generator/model/JavaSourceModelTest.java
+++ b/generator/src/test/java/com/fluxtion/generator/model/JavaSourceModelTest.java
@@ -54,7 +54,7 @@ public class JavaSourceModelTest {
 
         List<Object> nodeList = Arrays.asList(eRoot, e1, i1, i2, e2, e3, i3);
         //generate model
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(nodeList);
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(nodeList);
         SimpleEventProcessorModel sep = new SimpleEventProcessorModel(graph);
         sep.generateMetaModel();
         SepJavaSourceModelHugeFilter srcModel = new SepJavaSourceModelHugeFilter(sep);

--- a/generator/src/test/java/com/fluxtion/generator/model/SepModelTest.java
+++ b/generator/src/test/java/com/fluxtion/generator/model/SepModelTest.java
@@ -89,7 +89,7 @@ public class SepModelTest {
 
         List<Object> nodeList = Arrays.asList(eRoot, e1, i1, i2, e2, e3, i3);
         //generate model
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(nodeList);
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(nodeList);
         SimpleEventProcessorModel sep = new SimpleEventProcessorModel(graph);
         sep.generateMetaModel();
         //sizes
@@ -136,7 +136,7 @@ public class SepModelTest {
 
         List<Object> nodeList = Arrays.asList(eRoot, e1, i1, i2, e2, e3, i3);
         //generate model
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(nodeList);
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(nodeList);
         DefaultFilterDescriptionProducer filterProducer = new DefaultFilterDescriptionProducer();
         SimpleEventProcessorModel sep = new SimpleEventProcessorModel(graph);
         sep.generateMetaModel();
@@ -180,7 +180,7 @@ public class SepModelTest {
 
         List<Object> nodeList = Arrays.asList(eRoot, e1, i1, i2, e2, e3, i3);
         //generate model
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(nodeList);
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(nodeList);
         DefaultFilterDescriptionProducer filterProducer = new DefaultFilterDescriptionProducer();
         SimpleEventProcessorModel sep = new SimpleEventProcessorModel(graph, filterMap);
         sep.generateMetaModel();
@@ -227,7 +227,7 @@ public class SepModelTest {
 
         List<Object> nodeList = Arrays.asList(eRoot, e1, i1, i2, e2, e3, i3);
         //generate model
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(nodeList);
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(nodeList);
         SimpleEventProcessorModel sep = new SimpleEventProcessorModel(graph);
         sep.generateMetaModel();
         //
@@ -255,7 +255,7 @@ public class SepModelTest {
         i2.parents = new Object[]{testHandler2};
         root.parents = new Object[]{i1, i2};
 
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(timeHandler1, testHandler2, i1, i2, root);
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(timeHandler1, testHandler2, i1, i2, root);
         graph.generateDependencyTree();
         SimpleEventProcessorModel sep = new SimpleEventProcessorModel(graph);
         sep.generateMetaModel();
@@ -294,7 +294,7 @@ public class SepModelTest {
         i2.parents = new Object[]{filter_10_Handler, inverseHandler};
         root.parents = new Object[]{i1, i2};
 
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(noFilterHandler, filter_10_Handler, i1, i2, root, inverseHandler);
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(noFilterHandler, filter_10_Handler, i1, i2, root, inverseHandler);
         graph.generateDependencyTree();
         SimpleEventProcessorModel sep = new SimpleEventProcessorModel(graph);
         sep.generateMetaModel();
@@ -328,7 +328,7 @@ public class SepModelTest {
         unFilteredInter.parents = new Object[]{unFilteredTestHandler};
         root.parents = new Object[]{filteredInter, unFilteredInter};
 
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(filteredTestHandler, unFilteredTestHandler, filteredInter, unFilteredInter, root);
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(filteredTestHandler, unFilteredTestHandler, filteredInter, unFilteredInter, root);
         graph.generateDependencyTree();
         DefaultFilterDescriptionProducer filterProducer = new DefaultFilterDescriptionProducer();
         SimpleEventProcessorModel sep = new SimpleEventProcessorModel(graph);
@@ -369,7 +369,7 @@ public class SepModelTest {
         RootCB root = new RootCB("root");
         root.parents = new Object[]{thExt, thImpl};
 
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(thExt, thImpl, root);
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(thExt, thImpl, root);
         graph.generateDependencyTree();
         DefaultFilterDescriptionProducer filterProducer = new DefaultFilterDescriptionProducer();
         SimpleEventProcessorModel sep = new SimpleEventProcessorModel(graph);
@@ -398,7 +398,7 @@ public class SepModelTest {
         RootCB root = new RootCB("root");
         root.parents = new Object[]{thExt, thImpl};
 
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(thExt, thImpl, root);
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(thExt, thImpl, root);
         graph.generateDependencyTree();
         DefaultFilterDescriptionProducer filterProducer = new DefaultFilterDescriptionProducer();
         SimpleEventProcessorModel sep = new SimpleEventProcessorModel(graph);
@@ -427,7 +427,7 @@ public class SepModelTest {
         RootCB root = new RootCB("root");
         root.parents = new Object[]{thExt, thImpl};
 
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(thExt, thImpl, root);
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(thExt, thImpl, root);
         graph.generateDependencyTree();
         DefaultFilterDescriptionProducer filterProducer = new DefaultFilterDescriptionProducer();
         SimpleEventProcessorModel sep = new SimpleEventProcessorModel(graph);
@@ -468,7 +468,7 @@ public class SepModelTest {
         RootCB root = new RootCB("root");
         root.parents = new Object[]{thExt, thImpl};
 
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(thExt, thImpl, root);
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(thExt, thImpl, root);
         graph.generateDependencyTree();
         DefaultFilterDescriptionProducer filterProducer = new DefaultFilterDescriptionProducer();
         SimpleEventProcessorModel sep = new SimpleEventProcessorModel(graph);
@@ -515,7 +515,7 @@ public class SepModelTest {
         RootCB root = new RootCB("root");
         root.parents = new Object[]{ thImpl};
 
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(thImpl, root);
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(thImpl, root);
         graph.generateDependencyTree();
         DefaultFilterDescriptionProducer filterProducer = new DefaultFilterDescriptionProducer();
         SimpleEventProcessorModel sep = new SimpleEventProcessorModel(graph);
@@ -539,7 +539,7 @@ public class SepModelTest {
         complete1.parents = new Object[]{handler};
         root.parents = new Object[]{complete1};
 
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(handler, root, complete1);
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(handler, root, complete1);
         graph.generateDependencyTree();
         DefaultFilterDescriptionProducer filterProducer = new DefaultFilterDescriptionProducer();
         SimpleEventProcessorModel sep = new SimpleEventProcessorModel(graph);
@@ -575,7 +575,7 @@ public class SepModelTest {
         complete3.parents = new Object[]{noFilterEh};
         root.parents = new Object[]{complete1, complete2, complete3};
 
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(thExt, thImpl, noFilterEh, root, complete1, complete2, complete3);
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(thExt, thImpl, noFilterEh, root, complete1, complete2, complete3);
         graph.generateDependencyTree();
         DefaultFilterDescriptionProducer filterProducer = new DefaultFilterDescriptionProducer();
         SimpleEventProcessorModel sep = new SimpleEventProcessorModel(graph);
@@ -629,7 +629,7 @@ public class SepModelTest {
         filterMap.put(thExt, 100);
         filterMap.put(thImpl, 200);
 
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(thExt, thImpl, root);
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(thExt, thImpl, root);
         graph.generateDependencyTree();
         DefaultFilterDescriptionProducer filterProducer = new DefaultFilterDescriptionProducer();
         SimpleEventProcessorModel sep = new SimpleEventProcessorModel(graph, filterMap, null);
@@ -692,7 +692,7 @@ public class SepModelTest {
 
         List<Object> nodeList = Arrays.asList(eRoot, e1, pl_1, pl_2, e2, e3, i3);
         //generate model
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(nodeList);
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(nodeList);
         SimpleEventProcessorModel sep = new SimpleEventProcessorModel(graph);
         sep.generateMetaModel();
         final Map<Object, List<CbMethodHandle>> listenerMethodMap = sep.getParentUpdateListenerMethodMap();
@@ -732,7 +732,7 @@ public class SepModelTest {
 
         List<Object> nodeList = Arrays.asList(root, e1, e2, e3);
         //generate model
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(nodeList);
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(nodeList);
         SimpleEventProcessorModel sep = new SimpleEventProcessorModel(graph);
         sep.generateMetaModel();
         final Map<Object, List<CbMethodHandle>> listenerMethodMap = sep.getParentUpdateListenerMethodMap();
@@ -765,7 +765,7 @@ public class SepModelTest {
 
         List<Object> nodeList = Arrays.asList(eRoot, e1, pl_1, dirty_2, e2, e3, i3);
         //generate model
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(nodeList);
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(nodeList);
         SimpleEventProcessorModel sep = new SimpleEventProcessorModel(graph);
         sep.generateMetaModel(true);
         //

--- a/generator/src/test/java/com/fluxtion/generator/model/TopologicallySortedDependencyGraphTest.java
+++ b/generator/src/test/java/com/fluxtion/generator/model/TopologicallySortedDependencyGraphTest.java
@@ -42,7 +42,7 @@ import org.junit.Test;
  *
  * @author Greg Higgins
  */
-public class TopologicallySortedDependecyGraphTest {
+public class TopologicallySortedDependencyGraphTest {
 
     /**
      * Test of getSortedDependents method, of class
@@ -66,7 +66,7 @@ public class TopologicallySortedDependecyGraphTest {
             prevChild = child;
         }
 
-        TopologicallySortedDependecyGraph instance = new TopologicallySortedDependecyGraph(nodeList);
+        TopologicallySortedDependencyGraph instance = new TopologicallySortedDependencyGraph(nodeList);
         instance.generateDependencyTree();
 
         for (int i = 1; i < allNumbers.length; i++) {
@@ -97,7 +97,7 @@ public class TopologicallySortedDependecyGraphTest {
             prevChild = child;
         }
 
-        TopologicallySortedDependecyGraph graph = new TopologicallySortedDependecyGraph(nodeMap);
+        TopologicallySortedDependencyGraph graph = new TopologicallySortedDependencyGraph(nodeMap);
         graph.generateDependencyTree();
 
         for (int i = 1; i < allNumbers.length; i++) {
@@ -148,7 +148,7 @@ public class TopologicallySortedDependecyGraphTest {
         nodeList.add(odds);
         nodeList.add(root);
 
-        TopologicallySortedDependecyGraph instance = new TopologicallySortedDependecyGraph(nodeList);
+        TopologicallySortedDependencyGraph instance = new TopologicallySortedDependencyGraph(nodeList);
         instance.generateDependencyTree();
 
         assertThat(instance.getSortedDependents(allNumbers[0]),
@@ -205,7 +205,7 @@ public class TopologicallySortedDependecyGraphTest {
 
         List<Object> nodeList = Arrays.asList(eRoot, e1, i1, i2, e2, e3, i3);
         //generate model
-        TopologicallySortedDependecyGraph instance = new TopologicallySortedDependecyGraph(nodeList);
+        TopologicallySortedDependencyGraph instance = new TopologicallySortedDependencyGraph(nodeList);
         instance.generateDependencyTree();
         //
         assertThat(instance.getDirectChildren(i3),
@@ -224,7 +224,7 @@ public class TopologicallySortedDependecyGraphTest {
         RootCB eRoot = new RootCB("eRoot", noFilterEh);
         List<Object> nodeList = Arrays.asList(eRoot, e1, noFilterEh, th, eRoot);
         //generate model
-        TopologicallySortedDependecyGraph instance = new TopologicallySortedDependecyGraph(nodeList);
+        TopologicallySortedDependencyGraph instance = new TopologicallySortedDependencyGraph(nodeList);
         instance.generateDependencyTree();
         //
         assertEquals(4, instance.getSortedDependents().size());
@@ -250,7 +250,7 @@ public class TopologicallySortedDependecyGraphTest {
 
         List<Object> nodeList = Arrays.asList(eRoot, e1, i1, i2, e2, e3, i3);
         //generate model
-        TopologicallySortedDependecyGraph instance = new TopologicallySortedDependecyGraph(nodeList);
+        TopologicallySortedDependencyGraph instance = new TopologicallySortedDependencyGraph(nodeList);
         instance.generateDependencyTree();
         //
         assertThat(instance.getDirectParents(i2),
@@ -277,7 +277,7 @@ public class TopologicallySortedDependecyGraphTest {
 
         List<Object> nodeList = Arrays.asList(eRoot, e1, i1, i2, e3, eshared);
         //generate model
-        TopologicallySortedDependecyGraph instance = new TopologicallySortedDependecyGraph(nodeList);
+        TopologicallySortedDependencyGraph instance = new TopologicallySortedDependencyGraph(nodeList);
         instance.generateDependencyTree();
         //
         assertThat(instance.getDirectParents(i1),
@@ -309,7 +309,7 @@ public class TopologicallySortedDependecyGraphTest {
         
 //        GenerationContext context = new GenerationContext(config);
         //generate model
-        TopologicallySortedDependecyGraph instance = new TopologicallySortedDependecyGraph(config);
+        TopologicallySortedDependencyGraph instance = new TopologicallySortedDependencyGraph(config);
         instance.generateDependencyTree();
         //
         assertThat(instance.getDirectParents(i1),
@@ -331,7 +331,7 @@ public class TopologicallySortedDependecyGraphTest {
         EventHandlerCb e3 = config.addNode(new EventHandlerCb("e3", 3));
         NodeWithParentList eRoot = config.addNode(new NodeWithParentList(e1,eshared, e3));
         
-        TopologicallySortedDependecyGraph instance = new TopologicallySortedDependecyGraph(config);
+        TopologicallySortedDependencyGraph instance = new TopologicallySortedDependencyGraph(config);
         instance.generateDependencyTree();
         assertThat(instance.getDirectParents(eRoot),
                 containsInAnyOrder(e1, eshared, e3));

--- a/generator/src/test/java/com/fluxtion/generator/model/parentlistener/ParentListenerModelTest.java
+++ b/generator/src/test/java/com/fluxtion/generator/model/parentlistener/ParentListenerModelTest.java
@@ -20,7 +20,7 @@ package com.fluxtion.generator.model.parentlistener;
 import com.fluxtion.builder.node.SEPConfig;
 import com.fluxtion.generator.model.CbMethodHandle;
 import com.fluxtion.generator.model.SimpleEventProcessorModel;
-import com.fluxtion.generator.model.TopologicallySortedDependecyGraph;
+import com.fluxtion.generator.model.TopologicallySortedDependencyGraph;
 import com.fluxtion.generator.model.parentlistener.EventListeners.ChildConfigEventListener;
 import com.fluxtion.generator.model.parentlistener.EventListeners.ConfigEventListener;
 import com.fluxtion.generator.model.parentlistener.EventListeners.Node1Parent1ObjectListener;
@@ -45,7 +45,7 @@ import org.junit.Test;
 public class ParentListenerModelTest {
 
     private SimpleEventProcessorModel sep;
-    private TopologicallySortedDependecyGraph graph;
+    private TopologicallySortedDependencyGraph graph;
 
     @Before
     public void before() {
@@ -289,7 +289,7 @@ public class ParentListenerModelTest {
     }
 
     private Map<Object, List<CbMethodHandle>> generateListnerMap(SEPConfig config) throws Exception {
-        graph = new TopologicallySortedDependecyGraph(config);
+        graph = new TopologicallySortedDependencyGraph(config);
         sep = new SimpleEventProcessorModel(graph);
         sep.generateMetaModel();
         return sep.getParentUpdateListenerMethodMap();

--- a/generator/src/test/java/com/fluxtion/generator/targets/InjectedFactoryTest.java
+++ b/generator/src/test/java/com/fluxtion/generator/targets/InjectedFactoryTest.java
@@ -18,7 +18,7 @@
  */
 package com.fluxtion.generator.targets;
 
-import com.fluxtion.builder.node.DeclarativeNodeConiguration;
+import com.fluxtion.builder.node.DeclarativeNodeConfiguration;
 import com.fluxtion.builder.node.NodeFactory;
 import com.fluxtion.builder.node.SEPConfig;
 import static com.fluxtion.generator.targets.JavaGeneratorNames.test_injected_factory;
@@ -48,7 +48,7 @@ public class InjectedFactoryTest {
         //Factories
         Set<Class<? extends NodeFactory>> factoryList = new HashSet<>();
         factoryList.add(KeyProcessorFactory.class);
-        cfg.declarativeConfig = new DeclarativeNodeConiguration(null, factoryList, null);
+        cfg.declarativeConfig = new DeclarativeNodeConfiguration(null, factoryList, null);
         //generate
         JavaClass generatedClass = JavaTestGeneratorHelper.generateClass(cfg, test_injected_factory);
         assertEquals(3, generatedClass.getFields().length);
@@ -65,7 +65,7 @@ public class InjectedFactoryTest {
         Set<Class<? extends NodeFactory>> factoryList = new HashSet<>();
         factoryList.add(KeyProcessorFactory.class);
         cfg.maxFiltersInline = 10;
-        cfg.declarativeConfig = new DeclarativeNodeConiguration(null, factoryList, null);
+        cfg.declarativeConfig = new DeclarativeNodeConfiguration(null, factoryList, null);
         //generate
         JavaClass generatedClass = JavaTestGeneratorHelper.generateClass(cfg, test_injected_factory_variable_config);
         assertEquals(4, generatedClass.getFields().length);

--- a/generator/src/test/java/com/fluxtion/generator/util/BaseSepTest.java
+++ b/generator/src/test/java/com/fluxtion/generator/util/BaseSepTest.java
@@ -21,7 +21,7 @@ import com.fluxtion.api.StaticEventProcessor;
 import com.fluxtion.api.event.Event;
 import com.fluxtion.api.lifecycle.Lifecycle;
 import com.fluxtion.builder.generation.GenerationContext;
-import com.fluxtion.builder.node.DeclarativeNodeConiguration;
+import com.fluxtion.builder.node.DeclarativeNodeConfiguration;
 import com.fluxtion.builder.node.NodeFactory;
 import com.fluxtion.builder.node.SEPConfig;
 import com.fluxtion.generator.compiler.SepCompilerConfig;
@@ -88,10 +88,10 @@ public class BaseSepTest {
         }
     }
 
-    public static DeclarativeNodeConiguration factorySet(Class<? extends NodeFactory>... classes) {
+    public static DeclarativeNodeConfiguration factorySet(Class<? extends NodeFactory>... classes) {
         Set<Class<? extends NodeFactory>> factoryList = new HashSet<>();
         factoryList.addAll(Arrays.asList(classes));
-        DeclarativeNodeConiguration declarativeConfig = new DeclarativeNodeConiguration(null, factoryList, null);
+        DeclarativeNodeConfiguration declarativeConfig = new DeclarativeNodeConfiguration(null, factoryList, null);
         return declarativeConfig;
     }
 

--- a/generator/src/test/java/com/fluxtion/test/nodegen/AveragingNodeFactoryTest.java
+++ b/generator/src/test/java/com/fluxtion/test/nodegen/AveragingNodeFactoryTest.java
@@ -18,7 +18,7 @@
 package com.fluxtion.test.nodegen;
 
 import com.fluxtion.builder.generation.GenerationContext;
-import com.fluxtion.builder.node.DeclarativeNodeConiguration;
+import com.fluxtion.builder.node.DeclarativeNodeConfiguration;
 import com.fluxtion.builder.node.NodeFactory;
 import com.fluxtion.builder.node.SEPConfig;
 import com.fluxtion.generator.util.BaseSepTest;
@@ -43,7 +43,7 @@ public class AveragingNodeFactoryTest extends BaseSepTest {
         try {
             buildAndInitSep(AvgNodeConfig.class);
         } catch (Exception e) {
-//        wont instantiate becuase the factory only generates and does not 
+//        wont instantiate because the factory only generates and does not
 //        compile and add to classpath
         }
         //load source file and validate
@@ -79,7 +79,7 @@ public class AveragingNodeFactoryTest extends BaseSepTest {
             Map<Class, String> rootNodeMappings = new HashMap<>();
             rootNodeMappings.put(AveragingNode.class, "averagingNode");
 
-            declarativeConfig = new DeclarativeNodeConiguration(rootNodeMappings, factoryList, config);
+            declarativeConfig = new DeclarativeNodeConfiguration(rootNodeMappings, factoryList, config);
 
         }
     }


### PR DESCRIPTION
I only changed:
`GroupByIniitialiser` => `GroupByInitializer`
`DeclarativeNodeConiguration` => `DeclarativeNodeConfiguration`
`EventPublsher` => `EventPublisher`
`TopologicallySortedDependecyGraph` => `TopologicallySortedDependencyGraph`

Otherwise the PR would be huge and unreviewable. I also fixed some typo in the README.md


I missed the anniversary of #34 :smile: 