### PR TITLE
set fetch-depth for checkout action to be 0, equates to all history.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: develop
+          fetch-depth: 0
       - name: Setup java 1.8
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
Attempt to fix failing jgitflow release action