### PR TITLE
Refactoring subscription

### DIFF
--- a/compiler/src/main/java/com/fluxtion/compiler/generation/targets/InMemoryEventProcessor.java
+++ b/compiler/src/main/java/com/fluxtion/compiler/generation/targets/InMemoryEventProcessor.java
@@ -13,7 +13,7 @@ import com.fluxtion.runtime.callback.CallbackDispatcher;
 import com.fluxtion.runtime.callback.EventProcessorCallbackInternal;
 import com.fluxtion.runtime.callback.InternalEventProcessor;
 import com.fluxtion.runtime.event.Event;
-import com.fluxtion.runtime.input.EventProcessorFeed;
+import com.fluxtion.runtime.input.EventFeed;
 import com.fluxtion.runtime.input.SubscriptionManager;
 import com.fluxtion.runtime.input.SubscriptionManagerNode;
 import com.fluxtion.runtime.lifecycle.BatchHandler;
@@ -231,12 +231,12 @@ public class InMemoryEventProcessor implements EventProcessor, StaticEventProces
     }
 
     @Override
-    public void addEventProcessorFeed(EventProcessorFeed eventProcessorFeed) {
+    public void addEventFeed(EventFeed eventProcessorFeed) {
         subscriptionManager.addEventProcessorFeed(eventProcessorFeed);
     }
 
     @Override
-    public void removeEventProcessorFeed(EventProcessorFeed eventProcessorFeed) {
+    public void removeEventFeed(EventFeed eventProcessorFeed) {
         subscriptionManager.removeEventProcessorFeed(eventProcessorFeed);
     }
 

--- a/compiler/src/main/java/com/fluxtion/compiler/generation/targets/JavaSourceGenerator.java
+++ b/compiler/src/main/java/com/fluxtion/compiler/generation/targets/JavaSourceGenerator.java
@@ -30,7 +30,7 @@ import com.fluxtion.runtime.annotations.OnEventHandler;
 import com.fluxtion.runtime.annotations.OnParentUpdate;
 import com.fluxtion.runtime.audit.Auditor;
 import com.fluxtion.runtime.event.Event;
-import com.fluxtion.runtime.input.EventProcessorFeed;
+import com.fluxtion.runtime.input.EventFeed;
 import com.fluxtion.runtime.node.MutableEventProcessorContext;
 import net.vidageek.mirror.dsl.Mirror;
 import net.vidageek.mirror.list.dsl.MirrorList;
@@ -1128,7 +1128,7 @@ public class JavaSourceGenerator {
         importList.add(EventProcessorContext.class.getCanonicalName());
         importList.add(MutableEventProcessorContext.class.getCanonicalName());
         importList.add(Map.class.getCanonicalName());
-        importList.add(EventProcessorFeed.class.getCanonicalName());
+        importList.add(EventFeed.class.getCanonicalName());
         auditMethodString = "";
         String auditObjet = "private void auditEvent(Object typedEvent){\n";
         String auditEvent = String.format("private void auditEvent(%s typedEvent){\n", eventClassName);

--- a/compiler/src/main/resources/template/base/javaTemplate.vsl
+++ b/compiler/src/main/resources/template/base/javaTemplate.vsl
@@ -142,12 +142,12 @@ private final IdentityHashMap<Object, Consumer<Boolean>> dirtyFlagUpdateMap = ne
     }
 
     @Override
-    public void addEventProcessorFeed(EventProcessorFeed eventProcessorFeed) {
+    public void addEventFeed(EventFeed eventProcessorFeed) {
         subscriptionManager.addEventProcessorFeed(eventProcessorFeed);
     }
 
     @Override
-    public void removeEventProcessorFeed(EventProcessorFeed eventProcessorFeed) {
+    public void removeEventFeed(EventFeed eventProcessorFeed) {
         subscriptionManager.removeEventProcessorFeed(eventProcessorFeed);
     }
 

--- a/compiler/src/test/java/com/fluxtion/compiler/generation/input/SubscriptionTest.java
+++ b/compiler/src/test/java/com/fluxtion/compiler/generation/input/SubscriptionTest.java
@@ -5,7 +5,7 @@ import com.fluxtion.runtime.StaticEventProcessor;
 import com.fluxtion.runtime.annotations.OnEventHandler;
 import com.fluxtion.runtime.annotations.builder.Inject;
 import com.fluxtion.runtime.event.Signal.IntSignal;
-import com.fluxtion.runtime.input.EventProcessorFeed;
+import com.fluxtion.runtime.input.EventFeed;
 import com.fluxtion.runtime.input.SubscriptionManager;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
@@ -31,7 +31,7 @@ public class SubscriptionTest extends MultipleSepTargetInProcessTest {
                     new MySubscriberNode("subscriber_3")
             );
         });
-        sep.addEventProcessorFeed(new MyEventFeed(subscriptions));
+        sep.addEventFeed(new MyEventFeed(subscriptions));
 
         Assert.assertTrue(subscriptions.isEmpty());
         sep.publishIntSignal("subscriber_1", 10);
@@ -57,7 +57,7 @@ public class SubscriptionTest extends MultipleSepTargetInProcessTest {
     public void subscriberTearDownThenInit() {
         Set<Object> subscriptions = new HashSet<>();
         sep(c -> c.addNode(new MySubscriberNode("subscriber_1")));
-        sep.addEventProcessorFeed(new MyEventFeed(subscriptions));
+        sep.addEventFeed(new MyEventFeed(subscriptions));
 
         Assert.assertTrue(subscriptions.isEmpty());
         sep.publishIntSignal("subscriber_1", 10);
@@ -98,11 +98,16 @@ public class SubscriptionTest extends MultipleSepTargetInProcessTest {
 
     }
 
-    public static class MyEventFeed implements EventProcessorFeed {
+    public static class MyEventFeed implements EventFeed {
         private final Set<Object> subscriptions;
 
         public MyEventFeed(Set<Object> subscriptions) {
             this.subscriptions = subscriptions;
+        }
+
+        @Override
+        public void registerFeedTarget(StaticEventProcessor staticEventProcessor) {
+
         }
 
         @Override

--- a/runtime/src/main/java/com/fluxtion/runtime/StaticEventProcessor.java
+++ b/runtime/src/main/java/com/fluxtion/runtime/StaticEventProcessor.java
@@ -19,7 +19,7 @@ import com.fluxtion.runtime.annotations.OnEventHandler;
 import com.fluxtion.runtime.audit.EventLogControlEvent;
 import com.fluxtion.runtime.audit.EventLogControlEvent.LogLevel;
 import com.fluxtion.runtime.event.Signal;
-import com.fluxtion.runtime.input.EventProcessorFeed;
+import com.fluxtion.runtime.input.EventFeed;
 import com.fluxtion.runtime.lifecycle.Lifecycle;
 import com.fluxtion.runtime.node.EventHandlerNode;
 import com.fluxtion.runtime.stream.EventStream;
@@ -254,11 +254,11 @@ public interface StaticEventProcessor {
         return stream.get();
     }
 
-    default void addEventProcessorFeed(EventProcessorFeed eventProcessorFeed) {
+    default void addEventFeed(EventFeed eventProcessorFeed) {
         throw new UnsupportedOperationException("addEventProcessorFeed not implemented");
     }
 
-    default void removeEventProcessorFeed(EventProcessorFeed eventProcessorFeed) {
+    default void removeEventFeed(EventFeed eventProcessorFeed) {
         throw new UnsupportedOperationException("removeEventProcessorFeed not implemented");
     }
 

--- a/runtime/src/main/java/com/fluxtion/runtime/input/EventFeed.java
+++ b/runtime/src/main/java/com/fluxtion/runtime/input/EventFeed.java
@@ -2,7 +2,9 @@ package com.fluxtion.runtime.input;
 
 import com.fluxtion.runtime.StaticEventProcessor;
 
-public interface EventProcessorFeed {
+public interface EventFeed {
+
+    void registerFeedTarget(StaticEventProcessor staticEventProcessor);
 
     void subscribe(StaticEventProcessor target, Object subscriptionId);
 

--- a/runtime/src/main/java/com/fluxtion/runtime/input/SubscriptionManagerNode.java
+++ b/runtime/src/main/java/com/fluxtion/runtime/input/SubscriptionManagerNode.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 public final class SubscriptionManagerNode implements SubscriptionManager, NamedNode {
 
-    private final List<EventProcessorFeed> registeredFeeds = new ArrayList<>();
+    private final List<EventFeed> registeredFeeds = new ArrayList<>();
     private final Map<Object, Integer> subscriptionMap = new HashMap<>();
     private StaticEventProcessor eventProcessor = StaticEventProcessor.NULL_EVENTHANDLER;
 
@@ -19,14 +19,14 @@ public final class SubscriptionManagerNode implements SubscriptionManager, Named
         this.eventProcessor = eventProcessor;
     }
 
-    public void addEventProcessorFeed(EventProcessorFeed eventProcessorFeed) {
+    public void addEventProcessorFeed(EventFeed eventProcessorFeed) {
         if (!registeredFeeds.contains(eventProcessorFeed)) {
             registeredFeeds.add(eventProcessorFeed);
             subscriptionMap.keySet().forEach(e -> eventProcessorFeed.subscribe(eventProcessor, e));
         }
     }
 
-    public void removeEventProcessorFeed(EventProcessorFeed eventProcessorFeed) {
+    public void removeEventProcessorFeed(EventFeed eventProcessorFeed) {
         registeredFeeds.remove(eventProcessorFeed);
     }
 


### PR DESCRIPTION
- simplify subscription class names.
- Add EventFeed#registerFeedTarget callback. Notifies EventFeed this EventProcessor is able to accept subscriptions