### PR TITLE
EevntProcessor implements new ServiceRegistry interface to allow simp…

### DIFF
--- a/compiler/src/main/java/com/fluxtion/compiler/generation/targets/InMemoryEventProcessor.java
+++ b/compiler/src/main/java/com/fluxtion/compiler/generation/targets/InMemoryEventProcessor.java
@@ -544,6 +544,14 @@ public class InMemoryEventProcessor implements EventProcessor, StaticEventProces
         }
     }
 
+    public <T> T exportedService() {
+        return getExportedService();
+    }
+
+    public <T> T exportedService(Class<T> exportedServiceClass) {
+        return exportsService(exportedServiceClass) ? getExportedService() : null;
+    }
+
     @SneakyThrows
     @SuppressWarnings("unchecked")
     public <T> T getExportedService() {

--- a/compiler/src/test/java/com/fluxtion/compiler/generation/context/ExportedServiceFromContextTest.java
+++ b/compiler/src/test/java/com/fluxtion/compiler/generation/context/ExportedServiceFromContextTest.java
@@ -1,0 +1,97 @@
+package com.fluxtion.compiler.generation.context;
+
+import com.fluxtion.compiler.generation.util.CompiledAndInterpretedSepTest;
+import com.fluxtion.compiler.generation.util.MultipleSepTargetInProcessTest;
+import com.fluxtion.runtime.EventProcessorContext;
+import com.fluxtion.runtime.EventProcessorContextListener;
+import com.fluxtion.runtime.annotations.ExportService;
+import com.fluxtion.runtime.annotations.runtime.ServiceRegistered;
+import com.fluxtion.runtime.node.NamedNode;
+import lombok.Getter;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ExportedServiceFromContextTest extends MultipleSepTargetInProcessTest {
+    public ExportedServiceFromContextTest(CompiledAndInterpretedSepTest.SepTestConfig testConfig) {
+        super(testConfig);
+    }
+
+    @Test
+    public void contextListenerTest() {
+        sep(new MyBroadcastSubscriber());
+        MyBroadcastSubscriber subscriber = getField("MyBroadcastSubscriber");
+        Assert.assertNotNull("context should not be null", subscriber.getContext());
+    }
+
+    @Test
+    public void cbServiceTest() {
+        sep(new MyBroadcastSubscriber());
+
+        MyBroadcasterImpl myBroadcaster = new MyBroadcasterImpl();
+        sep.registerService(myBroadcaster, Broadcaster.class);
+
+        myBroadcaster.publish("hello");
+
+        MyBroadcastSubscriber subscriber = getField("MyBroadcastSubscriber");
+        Assert.assertEquals("hello", subscriber.getIn());
+    }
+
+
+    public interface BroadcastListener {
+        boolean newMessage(String in);
+    }
+
+    public interface Broadcaster {
+        void register(BroadcastListener cb);
+    }
+
+    private static class MyBroadcasterImpl implements Broadcaster {
+
+        private BroadcastListener cb;
+
+        @Override
+        public void register(BroadcastListener cb) {
+            this.cb = cb;
+        }
+
+        public void publish(String in) {
+            cb.newMessage(in);
+        }
+    }
+
+    public static class MyBroadcastSubscriber
+            implements
+            @ExportService BroadcastListener,
+            EventProcessorContextListener,
+            NamedNode {
+
+        @Getter
+        private String in;
+        @Getter
+        private EventProcessorContext context;
+        private Broadcaster broadcaster;
+
+        @Override
+        public void currentContext(EventProcessorContext currentContext) {
+            this.context = currentContext;
+        }
+
+        @ServiceRegistered
+        public void broadcaster(Broadcaster broadcaster) {
+            this.broadcaster = broadcaster;
+            broadcaster.register(context.getExportedService());
+        }
+
+        @Override
+        public boolean newMessage(String in) {
+            Assert.assertNotNull("broadcaster should be non-null", broadcaster);
+            this.in = in;
+            return false;
+        }
+
+        @Override
+        public String getName() {
+            return "MyBroadcastSubscriber";
+        }
+    }
+}

--- a/compiler/src/test/java/com/fluxtion/compiler/generation/service/ServiceTest.java
+++ b/compiler/src/test/java/com/fluxtion/compiler/generation/service/ServiceTest.java
@@ -38,6 +38,31 @@ public class ServiceTest extends MultipleSepTargetInProcessTest {
         Assert.assertEquals("", node.svc_A_name);
     }
 
+
+    @Test
+    public void svcRegisterShortcutTest() {
+        sep(c -> {
+            c.addNode(new ServiceListenerNode(), "myListener");
+        });
+
+        MyServiceImpl noName = new MyServiceImpl("no_name");
+        sep.registerService(noName, MyService.class);
+
+        MyServiceImpl svcA = new MyServiceImpl("svc_A");
+        sep.registerService(svcA, MyService.class, "svc_A");
+
+        ServiceListenerNode node = getField("myListener");
+        Assert.assertEquals("no_name", node.name);
+        Assert.assertEquals("svc_A", node.svc_A_name);
+
+        sep.deRegisterService(noName, MyService.class);
+        sep.deRegisterService(svcA, MyService.class, "svc_A");
+
+        Assert.assertEquals("", node.name);
+        Assert.assertEquals("", node.svc_A_name);
+
+    }
+
     public static class ServiceListenerNode {
 
         private String name;

--- a/runtime/src/main/java/com/fluxtion/runtime/EventProcessorContext.java
+++ b/runtime/src/main/java/com/fluxtion/runtime/EventProcessorContext.java
@@ -22,6 +22,10 @@ public interface EventProcessorContext {
 
     Clock getClock();
 
+    <T> T getExportedService(Class<T> exportedServiceClass);
+
+    <T> T getExportedService();
+
     /**
      * Retrieves an injected instance at runtime. Fails with {@link RuntimeException} if no instance is found
      * <p>

--- a/runtime/src/main/java/com/fluxtion/runtime/EventProcessorContextListener.java
+++ b/runtime/src/main/java/com/fluxtion/runtime/EventProcessorContextListener.java
@@ -1,0 +1,9 @@
+package com.fluxtion.runtime;
+
+/**
+ * Listener for the current {@link EventProcessorContext}
+ */
+public interface EventProcessorContextListener {
+
+    void currentContext(EventProcessorContext currentContext);
+}

--- a/runtime/src/main/java/com/fluxtion/runtime/StaticEventProcessor.java
+++ b/runtime/src/main/java/com/fluxtion/runtime/StaticEventProcessor.java
@@ -29,7 +29,7 @@ import com.fluxtion.runtime.node.InstanceSupplier;
 import com.fluxtion.runtime.output.SinkDeregister;
 import com.fluxtion.runtime.output.SinkRegistration;
 import com.fluxtion.runtime.service.Service;
-import com.fluxtion.runtime.service.ServiceListener;
+import com.fluxtion.runtime.service.ServiceRegistry;
 import com.fluxtion.runtime.time.ClockStrategy;
 
 import java.util.Map;
@@ -60,7 +60,7 @@ import java.util.function.*;
  *
  * @author Greg Higgins
  */
-public interface StaticEventProcessor extends ServiceListener, NodeDiscovery {
+public interface StaticEventProcessor extends ServiceRegistry, NodeDiscovery {
 
     StaticEventProcessor NULL_EVENTHANDLER = e -> {
     };

--- a/runtime/src/main/java/com/fluxtion/runtime/callback/InternalEventProcessor.java
+++ b/runtime/src/main/java/com/fluxtion/runtime/callback/InternalEventProcessor.java
@@ -20,4 +20,13 @@ public interface InternalEventProcessor {
     void setDirty(Object node, boolean dirtyFlag);
 
     <T> T getNodeById(String id) throws NoSuchFieldException;
+
+    default <T> T exportedService() {
+        return (T) this;
+    }
+
+    default <T> T exportedService(Class<T> exportedServiceClass) {
+        T svcExport = exportedService();
+        return exportedServiceClass.isInstance(svcExport) ? exportedService() : null;
+    }
 }

--- a/runtime/src/main/java/com/fluxtion/runtime/node/MutableEventProcessorContext.java
+++ b/runtime/src/main/java/com/fluxtion/runtime/node/MutableEventProcessorContext.java
@@ -27,6 +27,7 @@ public final class MutableEventProcessorContext implements EventProcessorContext
     @Getter
     @Setter
     private Clock clock = Clock.DEFAULT_CLOCK;
+    private InternalEventProcessor eventProcessorCallback;
 
     public MutableEventProcessorContext(
             @AssignToField("nodeNameLookup") NodeNameLookup nodeNameLookup,
@@ -56,6 +57,7 @@ public final class MutableEventProcessorContext implements EventProcessorContext
     }
 
     public void setEventProcessorCallback(InternalEventProcessor eventProcessorCallback) {
+        this.eventProcessorCallback = eventProcessorCallback;
         eventDispatcher.setEventProcessor(eventProcessorCallback);
     }
 
@@ -89,6 +91,16 @@ public final class MutableEventProcessorContext implements EventProcessorContext
 
     public <K, V> V put(K key, V value) {
         return (V) map.put(key, value);
+    }
+
+    @Override
+    public <T> T getExportedService(Class<T> exportedServiceClass) {
+        return eventProcessorCallback.exportedService(exportedServiceClass);
+    }
+
+    @Override
+    public <T> T getExportedService() {
+        return eventProcessorCallback.exportedService();
     }
 
     @Override

--- a/runtime/src/main/java/com/fluxtion/runtime/service/ServiceRegistry.java
+++ b/runtime/src/main/java/com/fluxtion/runtime/service/ServiceRegistry.java
@@ -1,0 +1,35 @@
+package com.fluxtion.runtime.service;
+
+import com.fluxtion.runtime.annotations.feature.Preview;
+
+@Preview
+public interface ServiceRegistry extends ServiceListener {
+
+    default <T> void registerService(T service) {
+        registerService(new Service<T>(service));
+    }
+
+    default <T> void registerService(T service, String serviceName) {
+        registerService(new Service<T>(service, serviceName));
+    }
+
+    default <S, T extends S> void registerService(T service, Class<S> serviceClass) {
+        registerService(new Service<S>(service, serviceClass));
+    }
+
+    default <S, T extends S> void registerService(T service, Class<S> serviceClass, String serviceName) {
+        registerService(new Service<S>(service, serviceClass, serviceName));
+    }
+
+    default <T> void deRegisterService(T service, String serviceName) {
+        deRegisterService(new Service<T>(service, serviceName));
+    }
+
+    default <S, T extends S> void deRegisterService(T service, Class<S> serviceClass) {
+        deRegisterService(new Service<S>(service, serviceClass));
+    }
+
+    default <S, T extends S> void deRegisterService(T service, Class<S> serviceClass, String serviceName) {
+        deRegisterService(new Service<S>(service, serviceClass, serviceName));
+    }
+}

--- a/runtime/src/main/java/com/fluxtion/runtime/service/ServiceRegistryNode.java
+++ b/runtime/src/main/java/com/fluxtion/runtime/service/ServiceRegistryNode.java
@@ -1,5 +1,6 @@
 package com.fluxtion.runtime.service;
 
+import com.fluxtion.runtime.EventProcessorContextListener;
 import com.fluxtion.runtime.annotations.ExportService;
 import com.fluxtion.runtime.annotations.builder.FluxtionIgnore;
 import com.fluxtion.runtime.annotations.feature.Preview;
@@ -72,6 +73,10 @@ public class ServiceRegistryNode
 
     @Override
     public void nodeRegistered(Object node, String nodeName) {
+        if (node instanceof EventProcessorContextListener) {
+            ((EventProcessorContextListener) node).currentContext(getEventProcessorContext());
+        }
+
         Class<?> clazz = node.getClass();
         Method[] methods = clazz.getMethods();
         for (Method method : methods) {


### PR DESCRIPTION
…ler registering of external services with an EventProcessor.

Adds exported service discovery to EventProcessorContext.

EventProcessorContextListener interface allows nodes to register for EventProcessorContext as a callback, removes need for inject annotation in nodes.