### PR TITLE
Adds helper methods for subscribing to event feeds

### DIFF
--- a/runtime/src/main/java/com/fluxtion/runtime/EventProcessorContext.java
+++ b/runtime/src/main/java/com/fluxtion/runtime/EventProcessorContext.java
@@ -147,4 +147,20 @@ public interface EventProcessorContext {
     default <V> V getInstanceById(String instanceId) throws NoSuchFieldException {
         return getNodeNameLookup().getInstanceById(instanceId);
     }
+
+    /**
+     * Creates a subscription to {@link com.fluxtion.runtime.input.EventFeed} registered with a matching feed name
+     * @param feedName the name to match on a registered {@link com.fluxtion.runtime.input.EventFeed}
+     */
+    default void subscribeToNamedFeed(String feedName) {
+        getSubscriptionManager().subscribeToNamedFeed(feedName);
+    }
+
+    /**
+     * Removes a subscription to {@link com.fluxtion.runtime.input.EventFeed} registered with a matching feed name
+     * @param feedName the name to match on a registered {@link com.fluxtion.runtime.input.EventFeed}
+     */
+    default void unSubscribeToNamedFeed(String feedName) {
+        getSubscriptionManager().unSubscribeToNamedFeed(feedName);
+    }
 }

--- a/runtime/src/main/java/com/fluxtion/runtime/input/SubscriptionManager.java
+++ b/runtime/src/main/java/com/fluxtion/runtime/input/SubscriptionManager.java
@@ -11,5 +11,9 @@ public interface SubscriptionManager {
 
     void subscribeToNamedFeed(EventSubscription<?> subscription);
 
+    void subscribeToNamedFeed(String feedName);
+
     void unSubscribeToNamedFeed(EventSubscription<?> subscription);
+
+    void unSubscribeToNamedFeed(String feedName);
 }

--- a/runtime/src/main/java/com/fluxtion/runtime/input/SubscriptionManagerNode.java
+++ b/runtime/src/main/java/com/fluxtion/runtime/input/SubscriptionManagerNode.java
@@ -4,6 +4,7 @@ import com.fluxtion.runtime.StaticEventProcessor;
 import com.fluxtion.runtime.annotations.TearDown;
 import com.fluxtion.runtime.annotations.runtime.ServiceDeregistered;
 import com.fluxtion.runtime.annotations.runtime.ServiceRegistered;
+import com.fluxtion.runtime.event.NamedFeedEvent;
 import com.fluxtion.runtime.node.EventSubscription;
 import com.fluxtion.runtime.node.NamedNode;
 
@@ -89,6 +90,11 @@ public final class SubscriptionManagerNode implements SubscriptionManager, Named
     }
 
     @Override
+    public void subscribeToNamedFeed(String feedName) {
+        subscribeToNamedFeed(new EventSubscription<>(feedName, Integer.MAX_VALUE, feedName, NamedFeedEvent.class));
+    }
+
+    @Override
     public void unSubscribeToNamedFeed(EventSubscription<?> subscription) {
         namedFeedSubscriptionMap.computeIfPresent(subscription, (k, i) -> {
             if (--i < 1) {
@@ -97,6 +103,11 @@ public final class SubscriptionManagerNode implements SubscriptionManager, Named
             }
             return i;
         });
+    }
+
+    @Override
+    public void unSubscribeToNamedFeed(String feedName) {
+        unSubscribeToNamedFeed(new EventSubscription<>(feedName, Integer.MAX_VALUE, feedName, NamedFeedEvent.class));
     }
 
     @TearDown


### PR DESCRIPTION
Adds helper methods for subscribing to event feeds, that only require a feed name as String:

EventProcessorContext#subscribeToNamedFeed
EventProcessorContext#unSubscribeToNamedFeed